### PR TITLE
feat: docs, examples, and gitignore for publish readiness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,8 @@ erl_crash.dump
 cheer-*.tar
 
 CLAUDE.md
+
+# Example project build artifacts
+examples/*/_build/
+examples/*/deps/
+examples/*/mix.lock

--- a/examples/devtool/lib/devtool/cli.ex
+++ b/examples/devtool/lib/devtool/cli.ex
@@ -1,0 +1,33 @@
+defmodule Devtool.CLI do
+  @moduledoc """
+  Multi-command CLI example with nested subcommands, lifecycle hooks,
+  param groups, and shell completion.
+
+  ## Try it
+
+      mix run -e 'Devtool.CLI.main(["server", "start"])'
+      mix run -e 'Devtool.CLI.main(["server", "start", "--port", "8080"])'
+      mix run -e 'Devtool.CLI.main(["db", "migrate", "--target", "20240101"])'
+      mix run -e 'Devtool.CLI.main(["db", "seed", "--env", "staging"])'
+      mix run -e 'Devtool.CLI.main(["--help"])'
+      mix run -e 'Devtool.CLI.main(["server", "--help"])'
+  """
+
+  use Cheer.Command
+
+  command "devtool" do
+    about "Developer toolkit"
+    version "0.1.0"
+
+    persistent_before_run fn args ->
+      Map.put(args, :start_time, System.monotonic_time(:millisecond))
+    end
+
+    subcommand Devtool.Server
+    subcommand Devtool.Db
+  end
+
+  def main(argv) do
+    Cheer.run(__MODULE__, argv, prog: "devtool")
+  end
+end

--- a/examples/devtool/lib/devtool/db.ex
+++ b/examples/devtool/lib/devtool/db.ex
@@ -1,0 +1,72 @@
+defmodule Devtool.Db do
+  use Cheer.Command
+
+  command "db" do
+    about "Database management"
+
+    subcommand Devtool.Db.Migrate
+    subcommand Devtool.Db.Seed
+  end
+end
+
+defmodule Devtool.Db.Migrate do
+  use Cheer.Command
+
+  command "migrate" do
+    about "Run database migrations"
+
+    option :target, type: :string, short: :t, help: "Target migration version"
+    option :dry_run, type: :boolean, help: "Show what would be run without applying"
+
+    before_run fn args ->
+      IO.puts("Connecting to database...")
+      args
+    end
+
+    after_run fn result ->
+      IO.puts("Done.")
+      result
+    end
+  end
+
+  @impl Cheer.Command
+  def run(args, _raw) do
+    prefix = if args[:dry_run], do: "[dry run] ", else: ""
+
+    case args[:target] do
+      nil -> IO.puts("#{prefix}Running all pending migrations...")
+      target -> IO.puts("#{prefix}Migrating to version #{target}...")
+    end
+
+    :ok
+  end
+end
+
+defmodule Devtool.Db.Seed do
+  use Cheer.Command
+
+  command "seed" do
+    about "Seed the database"
+
+    option :env, type: :string, default: "development",
+      choices: ["development", "staging", "test"],
+      help: "Target environment"
+
+    option :clean, type: :boolean, help: "Truncate tables before seeding"
+
+    validate fn args ->
+      if args[:clean] && args[:env] == "staging" do
+        {:error, "cannot use --clean with staging environment"}
+      else
+        :ok
+      end
+    end
+  end
+
+  @impl Cheer.Command
+  def run(args, _raw) do
+    if args[:clean], do: IO.puts("Truncating tables...")
+    IO.puts("Seeding #{args[:env]} database...")
+    :ok
+  end
+end

--- a/examples/devtool/lib/devtool/server.ex
+++ b/examples/devtool/lib/devtool/server.ex
@@ -1,0 +1,61 @@
+defmodule Devtool.Server do
+  use Cheer.Command
+
+  command "server" do
+    about "Server management"
+
+    subcommand Devtool.Server.Start
+    subcommand Devtool.Server.Stop
+  end
+end
+
+defmodule Devtool.Server.Start do
+  use Cheer.Command
+
+  command "start" do
+    about "Start the dev server"
+
+    option :port, type: :integer, short: :p, default: 4000, env: "DEV_PORT",
+      validate: fn p -> if p in 1024..65535, do: :ok, else: {:error, "port must be 1024-65535"} end,
+      help: "Port to listen on"
+
+    option :host, type: :string, short: :H, default: "localhost", help: "Bind address"
+
+    group :protocol, mutually_exclusive: true do
+      option :http, type: :boolean, help: "Use HTTP"
+      option :https, type: :boolean, help: "Use HTTPS"
+    end
+  end
+
+  @impl Cheer.Command
+  def run(args, _raw) do
+    protocol = if args[:https], do: "https", else: "http"
+    IO.puts("Starting server at #{protocol}://#{args[:host]}:#{args[:port]}")
+    IO.puts("(started in #{elapsed(args)}ms)")
+    :ok
+  end
+
+  defp elapsed(%{start_time: t}), do: System.monotonic_time(:millisecond) - t
+  defp elapsed(_), do: 0
+end
+
+defmodule Devtool.Server.Stop do
+  use Cheer.Command
+
+  command "stop" do
+    about "Stop the dev server"
+
+    option :force, type: :boolean, short: :f, help: "Force stop without draining"
+  end
+
+  @impl Cheer.Command
+  def run(args, _raw) do
+    if args[:force] do
+      IO.puts("Force stopping server...")
+    else
+      IO.puts("Gracefully stopping server...")
+    end
+
+    :ok
+  end
+end

--- a/examples/devtool/mix.exs
+++ b/examples/devtool/mix.exs
@@ -1,0 +1,19 @@
+defmodule Devtool.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :devtool,
+      version: "0.1.0",
+      elixir: "~> 1.15",
+      deps: deps(),
+      escript: [main_module: Devtool.CLI]
+    ]
+  end
+
+  defp deps do
+    [
+      {:cheer, path: "../.."}
+    ]
+  end
+end

--- a/examples/greeter/lib/greeter/cli.ex
+++ b/examples/greeter/lib/greeter/cli.ex
@@ -1,0 +1,53 @@
+defmodule Greeter.CLI do
+  @moduledoc """
+  Minimal single-command example showing arguments, options, validation,
+  defaults, and env var fallback.
+
+  ## Try it
+
+      mix run -e 'Greeter.CLI.main(["world"])'
+      mix run -e 'Greeter.CLI.main(["world", "--loud"])'
+      mix run -e 'Greeter.CLI.main(["world", "--greeting", "Hi"])'
+      mix run -e 'Greeter.CLI.main(["world", "--times", "3"])'
+      mix run -e 'Greeter.CLI.main(["--help"])'
+
+  Or build as an escript:
+
+      mix escript.build
+      ./greeter world --loud --times 3
+  """
+
+  use Cheer.Command
+
+  command "greeter" do
+    about "Greet someone with style"
+    version "1.0.0"
+
+    argument :name, type: :string, required: true, help: "Who to greet"
+
+    option :greeting, type: :string, default: "Hello", env: "GREETER_GREETING",
+      help: "Greeting word"
+
+    option :loud, type: :boolean, short: :l, help: "SHOUT the greeting"
+
+    option :times, type: :integer, short: :n, default: 1,
+      validate: fn n -> if n in 1..10, do: :ok, else: {:error, "times must be 1-10"} end,
+      help: "Repeat the greeting"
+  end
+
+  @impl Cheer.Command
+  def run(%{name: name} = args, _raw) do
+    greeting = "#{args[:greeting]}, #{name}!"
+    greeting = if args[:loud], do: String.upcase(greeting), else: greeting
+
+    for _ <- 1..args[:times] do
+      IO.puts(greeting)
+    end
+
+    :ok
+  end
+
+  def main(argv) do
+    Cheer.run(__MODULE__, argv, prog: "greeter")
+  end
+end

--- a/examples/greeter/mix.exs
+++ b/examples/greeter/mix.exs
@@ -1,0 +1,19 @@
+defmodule Greeter.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :greeter,
+      version: "0.1.0",
+      elixir: "~> 1.15",
+      deps: deps(),
+      escript: [main_module: Greeter.CLI]
+    ]
+  end
+
+  defp deps do
+    [
+      {:cheer, path: "../.."}
+    ]
+  end
+end

--- a/lib/cheer/command/dsl.ex
+++ b/lib/cheer/command/dsl.ex
@@ -4,6 +4,16 @@ defmodule Cheer.Command.DSL do
   lifecycle hooks, param groups, and validation.
   """
 
+  @doc """
+  Define a command block with the given `name`.
+
+  All DSL calls (`about`, `argument`, `option`, `subcommand`, etc.) go inside the block.
+
+      command "deploy" do
+        about "Deploy the app"
+        option :env, type: :string, required: true
+      end
+  """
   defmacro command(name, do: block) do
     quote do
       @cheer_command_name unquote(name)
@@ -11,10 +21,25 @@ defmodule Cheer.Command.DSL do
     end
   end
 
+  @doc "Set the command's description text, shown in help output."
   defmacro about(text), do: quote(do: @cheer_about(unquote(text)))
+
+  @doc "Set the command's version string, printed by `--version` / `-V`."
   defmacro version(text), do: quote(do: @cheer_version(unquote(text)))
+
+  @doc "Register a child subcommand module."
   defmacro subcommand(module), do: quote(do: @cheer_subcommands(unquote(module)))
 
+  @doc """
+  Declare a positional argument.
+
+  Arguments are matched in declaration order. Options:
+
+    * `:type` - `:string` (default), `:integer`, `:float`, or `:boolean`
+    * `:required` - `true` or `false` (default)
+    * `:help` - help text shown in `--help`
+    * `:validate` - `fn value -> :ok | {:error, msg} end`
+  """
   defmacro argument(name, opts \\ []) do
     {validate_ast, clean_opts} = Keyword.pop(opts, :validate)
 
@@ -33,6 +58,20 @@ defmodule Cheer.Command.DSL do
     end
   end
 
+  @doc """
+  Declare a named option (flag).
+
+  Options:
+
+    * `:type` - `:string` (default), `:integer`, `:float`, or `:boolean`
+    * `:short` - single-character alias atom (e.g. `:p` for `-p`)
+    * `:required` - `true` or `false` (default)
+    * `:default` - default value when not provided
+    * `:env` - environment variable name to read as fallback
+    * `:choices` - list of allowed values
+    * `:help` - help text shown in `--help`
+    * `:validate` - `fn value -> :ok | {:error, msg} end`
+  """
   defmacro option(name, opts \\ []) do
     {validate_ast, clean_opts} = Keyword.pop(opts, :validate)
 

--- a/lib/cheer/help.ex
+++ b/lib/cheer/help.ex
@@ -1,6 +1,12 @@
 defmodule Cheer.Help do
   @moduledoc """
   Auto-generates help text from command metadata.
+
+  Renders a formatted help page to stdout including usage line, description,
+  subcommands, arguments, options (with defaults, env vars, choices), param
+  groups, and built-in flags (`--help`, `--version`).
+
+  Called automatically when `--help` or `-h` is passed to any command.
   """
 
   @doc """

--- a/lib/cheer/router.ex
+++ b/lib/cheer/router.ex
@@ -1,8 +1,24 @@
 defmodule Cheer.Router do
   @moduledoc """
   Routes argv through the command tree and dispatches to the matched command.
+
+  Handles the full dispatch pipeline: subcommand matching, option parsing
+  (via `OptionParser`), default/env-var application, validation (required
+  fields, choices, custom validators, cross-param validators, groups), and
+  lifecycle hook execution.
+
+  This module is called internally by `Cheer.run/3` and is not typically
+  invoked directly.
   """
 
+  @doc """
+  Dispatch `argv` through the command tree rooted at `command`.
+
+  Options:
+
+    * `:prog` - program name for help/usage output
+    * `:parent_hooks` - (internal) accumulated persistent hooks from parent commands
+  """
   @spec dispatch(module(), [String.t()], keyword()) :: term()
   def dispatch(command, argv, opts \\ []) do
     parent_hooks = Keyword.get(opts, :parent_hooks, [])


### PR DESCRIPTION
## Summary

- Add `@doc` annotations to all public DSL macros (`command`, `about`, `version`, `subcommand`, `argument`, `option`) with full option descriptions
- Expand `@moduledoc` for `Router` and `Help` with pipeline/rendering details
- Add `@doc` to `Router.dispatch/3`
- Add `examples/greeter` -- minimal single-command CLI (args, options, validation, defaults, env var fallback)
- Add `examples/devtool` -- nested multi-command CLI (subcommands, lifecycle hooks, param groups, cross-param validation)
- Gitignore example build artifacts

## Coverage notes

Reviewed the two lower-coverage modules:
- **DSL (62.5%)** -- macro definition lines; the generated code is fully tested
- **Repl (62.16%)** -- interactive IO branches (`eof`, `error`, `quit`, `?`, `commands`); low value to test further

## Test plan

- [x] `mix compile --warnings-as-errors` passes
- [x] `mix test` -- 70 tests, 0 failures
- [x] `mix docs` builds without warnings
- [x] Both examples compile and run correctly