### PR TITLE
feat: OptionParser compatibility (count, multi, --no-*, --)

### DIFF
--- a/lib/cheer/command/dsl.ex
+++ b/lib/cheer/command/dsl.ex
@@ -63,14 +63,19 @@ defmodule Cheer.Command.DSL do
 
   Options:
 
-    * `:type` - `:string` (default), `:integer`, `:float`, or `:boolean`
+    * `:type` - `:string` (default), `:integer`, `:float`, `:boolean`, or `:count`
     * `:short` - single-character alias atom (e.g. `:p` for `-p`)
     * `:required` - `true` or `false` (default)
-    * `:default` - default value when not provided
+    * `:default` - default value when not provided (`:count` defaults to `0`, `:multi` defaults to `[]`)
+    * `:multi` - `true` to allow repeated flags collected into a list (e.g. `--tag a --tag b`)
     * `:env` - environment variable name to read as fallback
     * `:choices` - list of allowed values
     * `:help` - help text shown in `--help`
     * `:validate` - `fn value -> :ok | {:error, msg} end`
+
+  Boolean options automatically support `--no-<name>` negation (e.g. `--no-color`).
+
+  Extra positional arguments after `--` are collected into `args[:rest]`.
   """
   defmacro option(name, opts \\ []) do
     {validate_ast, clean_opts} = Keyword.pop(opts, :validate)

--- a/lib/cheer/completion.ex
+++ b/lib/cheer/completion.ex
@@ -163,6 +163,7 @@ defmodule Cheer.Completion do
 
   defp option_completions({name, opts}) do
     flags = ["--#{name}"]
+    flags = if Keyword.get(opts, :type) == :boolean, do: flags ++ ["--no-#{name}"], else: flags
     short = Keyword.get(opts, :short)
     if short, do: flags ++ ["-#{short}"], else: flags
   end

--- a/lib/cheer/help.ex
+++ b/lib/cheer/help.ex
@@ -63,6 +63,11 @@ defmodule Cheer.Help do
 
         help = Keyword.get(opt_opts, :help, "")
 
+        type = Keyword.get(opt_opts, :type, :string)
+
+        flag_name =
+          if type == :boolean, do: "[no-]#{name}", else: to_string(name)
+
         suffixes =
           []
           |> maybe_append(Keyword.get(opt_opts, :choices), fn choices ->
@@ -75,9 +80,17 @@ defmodule Cheer.Help do
             "[env: #{env}]"
           end)
 
+        suffixes =
+          if type == :count, do: suffixes ++ ["(repeatable)"], else: suffixes
+
+        suffixes =
+          if Keyword.get(opt_opts, :multi, false),
+            do: suffixes ++ ["(multiple)"],
+            else: suffixes
+
         suffix = if suffixes != [], do: " " <> Enum.join(suffixes, " "), else: ""
 
-        IO.puts("  #{short}--#{String.pad_trailing(to_string(name), 16)} #{help}#{suffix}")
+        IO.puts("  #{short}--#{String.pad_trailing(flag_name, 16)} #{help}#{suffix}")
       end
 
       IO.puts("")
@@ -129,6 +142,7 @@ defmodule Cheer.Help do
         end)
 
     parts = if meta.options != [], do: parts ++ ["[OPTIONS]"], else: parts
+    parts = if meta.subcommands == [], do: parts ++ ["[-- <args>...]"], else: parts
 
     Enum.join(parts, " ")
   end

--- a/lib/cheer/router.ex
+++ b/lib/cheer/router.ex
@@ -100,17 +100,22 @@ defmodule Cheer.Router do
     else
       args = apply_defaults(meta.options)
       args = apply_env_vars(args, meta.options)
-      args = Map.merge(args, Map.new(parsed))
+      args = Map.merge(args, build_parsed_map(parsed, meta.options))
+
+      {declared_positional, rest_args} = Enum.split(positional, length(meta.arguments))
 
       args =
         meta.arguments
-        |> Enum.zip(positional)
+        |> Enum.zip(declared_positional)
         |> Enum.reduce(args, fn {{name, arg_opts}, value}, acc ->
           Map.put(acc, name, coerce_arg(value, arg_opts))
         end)
 
+      args = Map.put(args, :rest, rest_args)
+
       missing =
-        missing_required(meta.arguments, args) ++ missing_required(meta.options, args)
+        missing_required(meta.arguments, args) ++
+          missing_required_options(meta.options, args)
 
       cond do
         missing != [] ->
@@ -135,6 +140,19 @@ defmodule Cheer.Router do
     params
     |> Enum.filter(fn {_name, o} -> Keyword.get(o, :required, false) end)
     |> Enum.reject(fn {name, _o} -> Map.has_key?(args, name) end)
+    |> Enum.map(fn {name, _o} -> name end)
+  end
+
+  defp missing_required_options(options, args) do
+    options
+    |> Enum.filter(fn {_name, o} -> Keyword.get(o, :required, false) end)
+    |> Enum.reject(fn {name, o} ->
+      case Map.fetch(args, name) do
+        {:ok, []} -> not Keyword.get(o, :multi, false)
+        {:ok, _} -> true
+        :error -> false
+      end
+    end)
     |> Enum.map(fn {name, _o} -> name end)
   end
 
@@ -165,10 +183,20 @@ defmodule Cheer.Router do
   # -- Defaults --
 
   defp apply_defaults(options) do
-    options
-    |> Enum.filter(fn {_name, opts} -> Keyword.has_key?(opts, :default) end)
-    |> Enum.reduce(%{}, fn {name, opts}, acc ->
-      Map.put(acc, name, Keyword.fetch!(opts, :default))
+    Enum.reduce(options, %{}, fn {name, opts}, acc ->
+      cond do
+        Keyword.has_key?(opts, :default) ->
+          Map.put(acc, name, Keyword.fetch!(opts, :default))
+
+        Keyword.get(opts, :type) == :count ->
+          Map.put(acc, name, 0)
+
+        Keyword.get(opts, :multi, false) ->
+          Map.put(acc, name, [])
+
+        true ->
+          acc
+      end
     end)
   end
 
@@ -310,7 +338,13 @@ defmodule Cheer.Router do
   defp build_option_parser_spec(options) do
     spec =
       Enum.map(options, fn {name, opts} ->
-        {name, Keyword.get(opts, :type, :string)}
+        type = Keyword.get(opts, :type, :string)
+
+        if Keyword.get(opts, :multi, false) do
+          {name, [type, :keep]}
+        else
+          {name, type}
+        end
       end)
 
     aliases =
@@ -319,6 +353,19 @@ defmodule Cheer.Router do
       |> Enum.map(fn {name, opts} -> {Keyword.fetch!(opts, :short), name} end)
 
     {spec, aliases}
+  end
+
+  defp build_parsed_map(parsed, options) do
+    multi_names =
+      for {name, opts} <- options, Keyword.get(opts, :multi, false), into: MapSet.new(), do: name
+
+    Enum.reduce(parsed, %{}, fn {key, value}, acc ->
+      if MapSet.member?(multi_names, key) do
+        Map.update(acc, key, [value], &(&1 ++ [value]))
+      else
+        Map.put(acc, key, value)
+      end
+    end)
   end
 
   # -- Output helpers --

--- a/test/cheer_test.exs
+++ b/test/cheer_test.exs
@@ -677,7 +677,7 @@ defmodule CheerTest do
   describe "Cheer.Test" do
     test "captures output and return value" do
       result = Cheer.Test.run(TestGreet, ["hello"])
-      assert result.return == {:ok, %{name: "hello"}}
+      assert result.return == {:ok, %{name: "hello", rest: []}}
       assert result.output == ""
     end
 
@@ -767,6 +767,170 @@ defmodule CheerTest do
       assert length(tree.subcommands) == 2
       names = Enum.map(tree.subcommands, & &1.name) |> Enum.sort()
       assert names == ["greet", "serve"]
+    end
+  end
+
+  # -- :count type ----------------------------------------------------------
+
+  defmodule TestCount do
+    use Cheer.Command
+
+    command "verbose" do
+      about("Test count")
+
+      option(:verbose, type: :count, short: :v, help: "Increase verbosity")
+      argument(:name, type: :string, required: true, help: "Name")
+    end
+
+    @impl Cheer.Command
+    def run(args, _raw), do: {:ok, args}
+  end
+
+  describe "count type" do
+    test "single flag" do
+      assert {:ok, args} = Cheer.run(TestCount, ["hello", "-v"])
+      assert args[:verbose] == 1
+    end
+
+    test "repeated flags" do
+      assert {:ok, args} = Cheer.run(TestCount, ["hello", "-v", "-v", "-v"])
+      assert args[:verbose] == 3
+    end
+
+    test "combined short flags" do
+      assert {:ok, args} = Cheer.run(TestCount, ["hello", "-vvv"])
+      assert args[:verbose] == 3
+    end
+
+    test "defaults to 0 when not provided" do
+      assert {:ok, args} = Cheer.run(TestCount, ["hello"])
+      assert args[:verbose] == 0
+    end
+
+    test "help text shows repeatable" do
+      output = capture_io(fn -> Cheer.run(TestCount, ["--help"]) end)
+      assert output =~ "(repeatable)"
+    end
+  end
+
+  # -- Multi-value options ---------------------------------------------------
+
+  defmodule TestMultiValue do
+    use Cheer.Command
+
+    command "multi" do
+      about("Test multi-value")
+
+      option(:tag, type: :string, multi: true, short: :t, help: "Tags")
+      option(:port, type: :integer, multi: true, help: "Ports")
+    end
+
+    @impl Cheer.Command
+    def run(args, _raw), do: {:ok, args}
+  end
+
+  defmodule TestMultiRequired do
+    use Cheer.Command
+
+    command "multi-req" do
+      about("Test multi required")
+
+      option(:tag, type: :string, multi: true, required: true, help: "Tags")
+    end
+
+    @impl Cheer.Command
+    def run(args, _raw), do: {:ok, args}
+  end
+
+  describe "multi-value options" do
+    test "collects repeated flags into a list" do
+      assert {:ok, args} = Cheer.run(TestMultiValue, ["--tag", "a", "--tag", "b"])
+      assert args[:tag] == ["a", "b"]
+    end
+
+    test "single value is still a list" do
+      assert {:ok, args} = Cheer.run(TestMultiValue, ["--tag", "solo"])
+      assert args[:tag] == ["solo"]
+    end
+
+    test "defaults to empty list" do
+      assert {:ok, args} = Cheer.run(TestMultiValue, [])
+      assert args[:tag] == []
+      assert args[:port] == []
+    end
+
+    test "works with short flags" do
+      assert {:ok, args} = Cheer.run(TestMultiValue, ["-t", "x", "-t", "y"])
+      assert args[:tag] == ["x", "y"]
+    end
+
+    test "works with integer type" do
+      assert {:ok, args} = Cheer.run(TestMultiValue, ["--port", "80", "--port", "443"])
+      assert args[:port] == [80, 443]
+    end
+
+    test "required multi rejects empty" do
+      output = capture_io(fn -> Cheer.run(TestMultiRequired, []) end)
+      assert output =~ "missing required"
+    end
+
+    test "required multi accepts values" do
+      assert {:ok, args} = Cheer.run(TestMultiRequired, ["--tag", "a"])
+      assert args[:tag] == ["a"]
+    end
+
+    test "help text shows multiple" do
+      output = capture_io(fn -> Cheer.run(TestMultiValue, ["--help"]) end)
+      assert output =~ "(multiple)"
+    end
+  end
+
+  # -- Boolean negation (--no-*) ---------------------------------------------
+
+  describe "boolean negation" do
+    test "--no-loud sets boolean to false" do
+      assert {:ok, args} = Cheer.run(TestGreet, ["hello", "--no-loud"])
+      assert args[:loud] == false
+    end
+
+    test "--no-verbose sets boolean to false" do
+      assert {:ok, args} = Cheer.run(TestDefaults, ["--no-verbose"])
+      assert args[:verbose] == false
+    end
+
+    test "help text shows [no-] for boolean options" do
+      output = capture_io(fn -> Cheer.run(TestGreet, ["--help"]) end)
+      assert output =~ "--[no-]loud"
+    end
+
+    test "completion includes --no- variants for booleans" do
+      script = Cheer.Completion.generate(TestDefaults, :bash, prog: "serve")
+      assert script =~ "--no-verbose"
+    end
+  end
+
+  # -- Double-dash separator -------------------------------------------------
+
+  describe "-- separator" do
+    test "extra args after -- are collected in :rest" do
+      assert {:ok, args} = Cheer.run(TestGreet, ["world", "--", "--not-a-flag", "extra"])
+      assert args[:name] == "world"
+      assert args[:rest] == ["--not-a-flag", "extra"]
+    end
+
+    test "no separator gives empty rest" do
+      assert {:ok, args} = Cheer.run(TestGreet, ["world"])
+      assert args[:rest] == []
+    end
+
+    test "separator with no extra args gives empty rest" do
+      assert {:ok, args} = Cheer.run(TestGreet, ["world", "--"])
+      assert args[:rest] == []
+    end
+
+    test "help usage line shows [-- <args>...]" do
+      output = capture_io(fn -> Cheer.run(TestGreet, ["--help"]) end)
+      assert output =~ "[-- <args>...]"
     end
   end
 end


### PR DESCRIPTION
## Summary

Four OptionParser compatibility features:

- **`:count` type** -- repeatable flags like `-vvv` producing `verbose: 3`. Auto-defaults to `0`. Help shows `(repeatable)`.
- **`multi: true`** -- repeated options collected into lists (`--tag a --tag b` -> `tag: ["a", "b"]`). Auto-defaults to `[]`. Required multi options correctly reject empty lists. Help shows `(multiple)`.
- **`--no-*` boolean negation** -- `--no-color` sets `color: false`. Help renders `--[no-]color`. Shell completion includes `--no-*` variants for all boolean options.
- **`--` separator** -- stops flag parsing; extra positional args collected in `args[:rest]`. Usage line shows `[-- <args>...]`.

## Test plan

- [x] `mix compile --warnings-as-errors`
- [x] `mix test` -- 91 tests (21 new), 0 failures
- [x] `mix format --check-formatted`
- [x] `mix docs` builds without warnings