### PR TITLE
feat: support help subcommand

### DIFF
--- a/lib/cheer/router.ex
+++ b/lib/cheer/router.ex
@@ -38,8 +38,26 @@ defmodule Cheer.Router do
       "--version" in argv or "-V" in argv ->
         print_version(meta)
 
+      match?(["help" | _], argv) ->
+        resolve_help(command, tl(argv), opts)
+
       true ->
         dispatch_command(command, meta, argv, Keyword.put(opts, :parent_hooks, hooks), hooks)
+    end
+  end
+
+  defp resolve_help(command, [], opts), do: Cheer.Help.print(command, opts)
+
+  defp resolve_help(command, [token | rest], opts) do
+    meta = command.__cheer_meta__()
+
+    case match_subcommand(meta.subcommands, [token]) do
+      {:ok, sub_module, _} ->
+        resolve_help(sub_module, rest, opts)
+
+      _ ->
+        IO.puts("error: unknown command '#{token}'")
+        :ok
     end
   end
 

--- a/test/cheer_test.exs
+++ b/test/cheer_test.exs
@@ -326,6 +326,27 @@ defmodule CheerTest do
     end
   end
 
+  # -- Help subcommand ---------------------------------------------------------
+
+  describe "help subcommand" do
+    test "help with no args shows root help" do
+      output = capture_io(fn -> Cheer.run(TestRoot, ["help"]) end)
+      assert output =~ "COMMANDS:"
+      assert output =~ "greet"
+    end
+
+    test "help <subcommand> shows subcommand help" do
+      output = capture_io(fn -> Cheer.run(TestRoot, ["help", "greet"]) end)
+      assert output =~ "Say hello"
+      assert output =~ "<name>"
+    end
+
+    test "help with unknown subcommand shows error" do
+      output = capture_io(fn -> Cheer.run(TestRoot, ["help", "nope"]) end)
+      assert output =~ "error: unknown command 'nope'"
+    end
+  end
+
   # -- Program name in help ----------------------------------------------------
 
   describe "program name" do


### PR DESCRIPTION
## Summary

- Adds clap-style `help <subcommand>` syntax so users can type `tool help greet` instead of `tool greet --help`
- Recursively walks the subcommand tree, supporting nested commands (`tool help sub1 sub2`)
- Shows an error for unknown subcommands (`tool help nope` -> `error: unknown command 'nope'`)

## Test plan

- [x] `help` with no args shows root help
- [x] `help <subcommand>` shows subcommand help
- [x] `help <unknown>` shows error message
- [x] All existing tests pass (73 total)