### PR TITLE
feat: clap parity batch 1 -- 6 new features

### DIFF
--- a/lib/cheer/command.ex
+++ b/lib/cheer/command.ex
@@ -38,7 +38,11 @@ defmodule Cheer.Command do
 
       Module.register_attribute(__MODULE__, :cheer_command_name, accumulate: false)
       Module.register_attribute(__MODULE__, :cheer_about, accumulate: false)
+      Module.register_attribute(__MODULE__, :cheer_long_about, accumulate: false)
       Module.register_attribute(__MODULE__, :cheer_version, accumulate: false)
+      Module.register_attribute(__MODULE__, :cheer_before_help, accumulate: false)
+      Module.register_attribute(__MODULE__, :cheer_after_help, accumulate: false)
+      Module.register_attribute(__MODULE__, :cheer_aliases, accumulate: false)
       Module.register_attribute(__MODULE__, :cheer_arguments, accumulate: true)
       Module.register_attribute(__MODULE__, :cheer_options, accumulate: true)
       Module.register_attribute(__MODULE__, :cheer_subcommands, accumulate: true)

--- a/lib/cheer/command/compiler.ex
+++ b/lib/cheer/command/compiler.ex
@@ -7,7 +7,11 @@ defmodule Cheer.Command.Compiler do
   defmacro __before_compile__(env) do
     name = Module.get_attribute(env.module, :cheer_command_name) || ""
     about = Module.get_attribute(env.module, :cheer_about) || ""
+    long_about = Module.get_attribute(env.module, :cheer_long_about)
     version = Module.get_attribute(env.module, :cheer_version)
+    before_help = Module.get_attribute(env.module, :cheer_before_help)
+    after_help = Module.get_attribute(env.module, :cheer_after_help)
+    aliases = Module.get_attribute(env.module, :cheer_aliases) || []
     arguments = Module.get_attribute(env.module, :cheer_arguments) |> Enum.reverse()
     options = Module.get_attribute(env.module, :cheer_options) |> Enum.reverse()
     subcommands = Module.get_attribute(env.module, :cheer_subcommands) |> Enum.reverse()
@@ -76,7 +80,11 @@ defmodule Cheer.Command.Compiler do
         %{
           name: unquote(name),
           about: unquote(about),
+          long_about: unquote(long_about),
           version: unquote(version),
+          before_help: unquote(before_help),
+          after_help: unquote(after_help),
+          aliases: unquote(aliases),
           arguments: unquote(arguments_expr),
           options: unquote(options_expr),
           subcommands: unquote(subcommands),

--- a/lib/cheer/command/dsl.ex
+++ b/lib/cheer/command/dsl.ex
@@ -24,8 +24,20 @@ defmodule Cheer.Command.DSL do
   @doc "Set the command's description text, shown in help output."
   defmacro about(text), do: quote(do: @cheer_about(unquote(text)))
 
+  @doc "Set the command's extended description, shown by `--help` (long form)."
+  defmacro long_about(text), do: quote(do: @cheer_long_about(unquote(text)))
+
   @doc "Set the command's version string, printed by `--version` / `-V`."
   defmacro version(text), do: quote(do: @cheer_version(unquote(text)))
+
+  @doc "Set text displayed before the auto-generated help."
+  defmacro before_help(text), do: quote(do: @cheer_before_help(unquote(text)))
+
+  @doc "Set text displayed after the auto-generated help."
+  defmacro after_help(text), do: quote(do: @cheer_after_help(unquote(text)))
+
+  @doc "Set subcommand aliases (e.g. `aliases [\"co\", \"ck\"]` for `checkout`)."
+  defmacro aliases(list), do: quote(do: @cheer_aliases(unquote(list)))
 
   @doc "Register a child subcommand module."
   defmacro subcommand(module), do: quote(do: @cheer_subcommands(unquote(module)))
@@ -38,6 +50,9 @@ defmodule Cheer.Command.DSL do
     * `:type` - `:string` (default), `:integer`, `:float`, or `:boolean`
     * `:required` - `true` or `false` (default)
     * `:help` - help text shown in `--help`
+    * `:long_help` - extended help text shown by `--help` (long form)
+    * `:value_name` - placeholder name in help (e.g. `"FILE"`)
+    * `:hide` - `true` to hide from help output
     * `:validate` - `fn value -> :ok | {:error, msg} end`
   """
   defmacro argument(name, opts \\ []) do
@@ -71,6 +86,10 @@ defmodule Cheer.Command.DSL do
     * `:env` - environment variable name to read as fallback
     * `:choices` - list of allowed values
     * `:help` - help text shown in `--help`
+    * `:long_help` - extended help text shown by `--help` (long form)
+    * `:value_name` - placeholder name in help (e.g. `"FILE"`)
+    * `:hide` - `true` to hide from help output
+    * `:global` - `true` to propagate to all subcommands
     * `:validate` - `fn value -> :ok | {:error, msg} end`
 
   Boolean options automatically support `--no-<name>` negation (e.g. `--no-color`).

--- a/lib/cheer/help.ex
+++ b/lib/cheer/help.ex
@@ -6,7 +6,9 @@ defmodule Cheer.Help do
   subcommands, arguments, options (with defaults, env vars, choices), param
   groups, and built-in flags (`--help`, `--version`).
 
-  Called automatically when `--help` or `-h` is passed to any command.
+  Supports short help (`-h`) and long help (`--help`) modes. When long help
+  is available (via `long_about` or `long_help`), `--help` displays the
+  extended version while `-h` displays the short version.
   """
 
   @doc """
@@ -14,59 +16,103 @@ defmodule Cheer.Help do
 
   Options:
     * `:prog` - program name for usage line (default: command name)
+    * `:long` - `true` to print long help (default: `false`)
   """
   @spec print(module(), keyword()) :: :ok
   def print(command, opts \\ []) do
     meta = command.__cheer_meta__()
     prog = Keyword.get(opts, :prog) || meta.name
+    long = Keyword.get(opts, :long, false)
+
+    if meta[:before_help] do
+      IO.puts(meta.before_help)
+      IO.puts("")
+    end
 
     IO.puts("")
     IO.puts(format_usage(meta, prog))
     IO.puts("")
 
-    if meta.about != "" do
-      IO.puts(meta.about)
+    about_text = if long, do: meta[:long_about] || meta.about, else: meta.about
+
+    if about_text && about_text != "" do
+      IO.puts(about_text)
       IO.puts("")
     end
 
-    if meta.subcommands != [] do
+    visible_subcommands =
+      Enum.reject(meta.subcommands, fn sub ->
+        sub_meta = sub.__cheer_meta__()
+        Map.get(sub_meta, :hide, false)
+      end)
+
+    if visible_subcommands != [] do
       IO.puts("COMMANDS:")
 
-      for sub <- meta.subcommands do
+      for sub <- visible_subcommands do
         sub_meta = sub.__cheer_meta__()
-        IO.puts("  #{String.pad_trailing(sub_meta.name, 20)} #{sub_meta.about}")
+        cmd_aliases = Map.get(sub_meta, :aliases, [])
+        alias_str = if cmd_aliases != [], do: " (#{Enum.join(cmd_aliases, ", ")})", else: ""
+        IO.puts("  #{String.pad_trailing(sub_meta.name <> alias_str, 20)} #{sub_meta.about}")
       end
 
       IO.puts("")
     end
 
-    if meta.arguments != [] do
+    visible_arguments =
+      Enum.reject(meta.arguments, fn {_name, arg_opts} ->
+        Keyword.get(arg_opts, :hide, false)
+      end)
+
+    if visible_arguments != [] do
       IO.puts("ARGUMENTS:")
 
-      for {name, arg_opts} <- meta.arguments do
-        help = Keyword.get(arg_opts, :help, "")
+      for {name, arg_opts} <- visible_arguments do
+        display_name = Keyword.get(arg_opts, :value_name, Atom.to_string(name))
+        help = pick_help(arg_opts, long)
         required = if Keyword.get(arg_opts, :required, false), do: " (required)", else: ""
-        IO.puts("  #{String.pad_trailing("<#{name}>", 20)} #{help}#{required}")
+        IO.puts("  #{String.pad_trailing("<#{display_name}>", 20)} #{help}#{required}")
       end
 
       IO.puts("")
     end
 
-    if meta.options != [] do
+    # Merge inherited global options from parents
+    parent_globals = Keyword.get(opts, :parent_globals, [])
+
+    inherited_globals =
+      Enum.reject(parent_globals, fn {name, _} ->
+        Enum.any?(meta.options, fn {n, _} -> n == name end)
+      end)
+
+    all_options = meta.options ++ inherited_globals
+
+    visible_options =
+      Enum.reject(all_options, fn {_name, opt_opts} ->
+        Keyword.get(opt_opts, :hide, false)
+      end)
+
+    if visible_options != [] do
       IO.puts("OPTIONS:")
 
-      for {name, opt_opts} <- meta.options do
+      for {name, opt_opts} <- visible_options do
         short =
           if Keyword.has_key?(opt_opts, :short),
             do: "-#{Keyword.get(opt_opts, :short)}, ",
             else: "    "
 
-        help = Keyword.get(opt_opts, :help, "")
+        help = pick_help(opt_opts, long)
 
         type = Keyword.get(opt_opts, :type, :string)
 
         flag_name =
           if type == :boolean, do: "[no-]#{name}", else: to_string(name)
+
+        value_suffix =
+          case Keyword.get(opt_opts, :value_name) do
+            nil -> ""
+            vn -> " <#{vn}>"
+          end
 
         suffixes =
           []
@@ -88,9 +134,16 @@ defmodule Cheer.Help do
             do: suffixes ++ ["(multiple)"],
             else: suffixes
 
+        suffixes =
+          if Keyword.get(opt_opts, :global, false),
+            do: suffixes ++ ["(global)"],
+            else: suffixes
+
         suffix = if suffixes != [], do: " " <> Enum.join(suffixes, " "), else: ""
 
-        IO.puts("  #{short}--#{String.pad_trailing(flag_name, 16)} #{help}#{suffix}")
+        IO.puts(
+          "  #{short}--#{String.pad_trailing(flag_name <> value_suffix, 16)} #{help}#{suffix}"
+        )
       end
 
       IO.puts("")
@@ -119,8 +172,19 @@ defmodule Cheer.Help do
       IO.puts("  -V, --version           Print version")
     end
 
+    if meta[:after_help] do
+      IO.puts("")
+      IO.puts(meta.after_help)
+    end
+
     :ok
   end
+
+  defp pick_help(opts, true),
+    do: Keyword.get(opts, :long_help) || Keyword.get(opts, :help, "")
+
+  defp pick_help(opts, false),
+    do: Keyword.get(opts, :help, "")
 
   defp maybe_append(list, nil, _fun), do: list
   defp maybe_append(list, value, fun), do: list ++ [fun.(value)]
@@ -135,10 +199,19 @@ defmodule Cheer.Help do
         parts
       end
 
+    visible_arguments =
+      Enum.reject(meta.arguments, fn {_name, arg_opts} ->
+        Keyword.get(arg_opts, :hide, false)
+      end)
+
     parts =
       parts ++
-        Enum.map(meta.arguments, fn {name, arg_opts} ->
-          if Keyword.get(arg_opts, :required, false), do: "<#{name}>", else: "[#{name}]"
+        Enum.map(visible_arguments, fn {name, arg_opts} ->
+          display_name = Keyword.get(arg_opts, :value_name, Atom.to_string(name))
+
+          if Keyword.get(arg_opts, :required, false),
+            do: "<#{display_name}>",
+            else: "[#{display_name}]"
         end)
 
     parts = if meta.options != [], do: parts ++ ["[OPTIONS]"], else: parts

--- a/lib/cheer/router.ex
+++ b/lib/cheer/router.ex
@@ -28,11 +28,40 @@ defmodule Cheer.Router do
   defp dispatch_with_hooks(command, argv, opts, parent_hooks) do
     meta = command.__cheer_meta__()
 
+    # Accumulate global options from this command
+    parent_globals = Keyword.get(opts, :parent_globals, [])
+
+    global_opts =
+      Enum.filter(meta.options, fn {_name, o} -> Keyword.get(o, :global, false) end)
+
+    accumulated_globals = parent_globals ++ global_opts
+    opts = Keyword.put(opts, :parent_globals, accumulated_globals)
+
     # Accumulate persistent hooks from this command
     hooks = parent_hooks ++ Map.get(meta, :persistent_before_run, [])
 
+    # If the first token matches a subcommand, dispatch to it before checking
+    # flags. This ensures `tool sub --help` shows the subcommand's help.
+    first_is_subcommand =
+      case argv do
+        [token | _] ->
+          Enum.any?(meta.subcommands, fn sub ->
+            sub_meta = sub.__cheer_meta__()
+            sub_meta.name == token or token in Map.get(sub_meta, :aliases, [])
+          end)
+
+        _ ->
+          false
+      end
+
     cond do
-      "--help" in argv or "-h" in argv ->
+      first_is_subcommand ->
+        dispatch_command(command, meta, argv, Keyword.put(opts, :parent_hooks, hooks), hooks)
+
+      "--help" in argv ->
+        Cheer.Help.print(command, Keyword.put(opts, :long, true))
+
+      "-h" in argv ->
         Cheer.Help.print(command, opts)
 
       "--version" in argv or "-V" in argv ->
@@ -46,7 +75,8 @@ defmodule Cheer.Router do
     end
   end
 
-  defp resolve_help(command, [], opts), do: Cheer.Help.print(command, opts)
+  defp resolve_help(command, [], opts),
+    do: Cheer.Help.print(command, Keyword.put(opts, :long, true))
 
   defp resolve_help(command, [token | rest], opts) do
     meta = command.__cheer_meta__()
@@ -107,7 +137,17 @@ defmodule Cheer.Router do
   # -- Parsing pipeline --
 
   defp parse_and_validate(command, meta, argv, opts) do
-    {option_parser_opts, option_aliases} = build_option_parser_spec(meta.options)
+    # Merge parent global options with this command's options
+    parent_globals = Keyword.get(opts, :parent_globals, [])
+
+    inherited_globals =
+      Enum.reject(parent_globals, fn {name, _} ->
+        Enum.any?(meta.options, fn {n, _} -> n == name end)
+      end)
+
+    all_options = meta.options ++ inherited_globals
+
+    {option_parser_opts, option_aliases} = build_option_parser_spec(all_options)
 
     {parsed, positional, invalid} =
       OptionParser.parse(argv, strict: option_parser_opts, aliases: option_aliases)
@@ -116,9 +156,9 @@ defmodule Cheer.Router do
       print_invalid_options_error(command, invalid, opts)
       :handled
     else
-      args = apply_defaults(meta.options)
-      args = apply_env_vars(args, meta.options)
-      args = Map.merge(args, build_parsed_map(parsed, meta.options))
+      args = apply_defaults(all_options)
+      args = apply_env_vars(args, all_options)
+      args = Map.merge(args, build_parsed_map(parsed, all_options))
 
       {declared_positional, rest_args} = Enum.split(positional, length(meta.arguments))
 
@@ -133,7 +173,7 @@ defmodule Cheer.Router do
 
       missing =
         missing_required(meta.arguments, args) ++
-          missing_required_options(meta.options, args)
+          missing_required_options(all_options, args)
 
       cond do
         missing != [] ->
@@ -142,7 +182,7 @@ defmodule Cheer.Router do
 
         true ->
           with :ok <- validate_groups(args, Map.get(meta, :groups, %{})),
-               :ok <- validate_params(args, meta.options),
+               :ok <- validate_params(args, all_options),
                :ok <- run_validators(args, Map.get(meta, :validators, [])) do
             {:ok, args}
           else
@@ -333,7 +373,11 @@ defmodule Cheer.Router do
     found =
       Enum.find_value(subcommands, nil, fn sub_module ->
         sub_meta = sub_module.__cheer_meta__()
-        if sub_meta.name == token, do: {:ok, sub_module, rest}
+        cmd_aliases = Map.get(sub_meta, :aliases, [])
+
+        if sub_meta.name == token or token in cmd_aliases do
+          {:ok, sub_module, rest}
+        end
       end)
 
     case found do
@@ -402,7 +446,11 @@ defmodule Cheer.Router do
 
     # "Did you mean?" suggestion
     if meta.subcommands != [] do
-      names = Enum.map(meta.subcommands, & &1.__cheer_meta__().name)
+      names =
+        Enum.flat_map(meta.subcommands, fn sub ->
+          sub_meta = sub.__cheer_meta__()
+          [sub_meta.name | Map.get(sub_meta, :aliases, [])]
+        end)
 
       case suggest(token, names) do
         nil -> :ok

--- a/test/cheer_test.exs
+++ b/test/cheer_test.exs
@@ -954,4 +954,277 @@ defmodule CheerTest do
       assert output =~ "[-- <args>...]"
     end
   end
+
+  # -- Hidden options and commands (#10) ---------------------------------------
+
+  defmodule TestHidden do
+    use Cheer.Command
+
+    command "tool" do
+      about("Tool with hidden stuff")
+
+      option(:debug, type: :boolean, hide: true, help: "Debug mode")
+      option(:verbose, type: :boolean, short: :v, help: "Verbose output")
+      argument(:input, type: :string, hide: true, help: "Hidden input")
+    end
+
+    @impl Cheer.Command
+    def run(args, _raw), do: {:ok, args}
+  end
+
+  describe "hidden options and arguments" do
+    test "hidden option is not shown in help" do
+      output = capture_io(fn -> Cheer.run(TestHidden, ["--help"]) end)
+      refute output =~ "debug"
+      assert output =~ "verbose"
+    end
+
+    test "hidden option still parses" do
+      assert {:ok, %{debug: true}} = Cheer.run(TestHidden, ["--debug"])
+    end
+
+    test "hidden argument is not shown in help" do
+      output = capture_io(fn -> Cheer.run(TestHidden, ["--help"]) end)
+      refute output =~ "<input>"
+    end
+
+    test "hidden argument still parses" do
+      assert {:ok, %{input: "foo"}} = Cheer.run(TestHidden, ["foo"])
+    end
+  end
+
+  # -- Subcommand aliases (#12) ------------------------------------------------
+
+  defmodule TestAliasedSub do
+    use Cheer.Command
+
+    command "checkout" do
+      about("Check out a branch")
+      aliases(["co", "ck"])
+
+      argument(:branch, type: :string, required: true, help: "Branch name")
+    end
+
+    @impl Cheer.Command
+    def run(args, _raw), do: {:ok, args}
+  end
+
+  defmodule TestAliasRoot do
+    use Cheer.Command
+
+    command "git" do
+      about("Git-like tool")
+
+      subcommand(CheerTest.TestAliasedSub)
+    end
+  end
+
+  describe "subcommand aliases" do
+    test "dispatches via primary name" do
+      assert {:ok, %{branch: "main"}} = Cheer.run(TestAliasRoot, ["checkout", "main"])
+    end
+
+    test "dispatches via alias" do
+      assert {:ok, %{branch: "main"}} = Cheer.run(TestAliasRoot, ["co", "main"])
+    end
+
+    test "dispatches via second alias" do
+      assert {:ok, %{branch: "main"}} = Cheer.run(TestAliasRoot, ["ck", "main"])
+    end
+
+    test "aliases shown in help" do
+      output = capture_io(fn -> Cheer.run(TestAliasRoot, ["--help"]) end)
+      assert output =~ "checkout"
+      assert output =~ "co, ck"
+    end
+
+    test "did you mean considers aliases" do
+      output = capture_io(fn -> Cheer.run(TestAliasRoot, ["checkou"]) end)
+      assert output =~ "Did you mean"
+      assert output =~ "checkout"
+    end
+  end
+
+  # -- Long help (#9) ----------------------------------------------------------
+
+  defmodule TestLongHelp do
+    use Cheer.Command
+
+    command "analyzer" do
+      about("Analyze data")
+      long_about("Analyze data from multiple sources.\nSupports CSV, JSON, and Parquet formats.")
+
+      option(:format,
+        type: :string,
+        help: "Output format",
+        long_help: "Output format for the analysis results.\nSupported: json, table, csv."
+      )
+    end
+
+    @impl Cheer.Command
+    def run(args, _raw), do: {:ok, args}
+  end
+
+  describe "long help" do
+    test "-h shows short about" do
+      output = capture_io(fn -> Cheer.run(TestLongHelp, ["-h"]) end)
+      assert output =~ "Analyze data"
+      refute output =~ "Supports CSV, JSON, and Parquet"
+    end
+
+    test "--help shows long about" do
+      output = capture_io(fn -> Cheer.run(TestLongHelp, ["--help"]) end)
+      assert output =~ "Supports CSV, JSON, and Parquet"
+    end
+
+    test "-h shows short option help" do
+      output = capture_io(fn -> Cheer.run(TestLongHelp, ["-h"]) end)
+      assert output =~ "Output format"
+      refute output =~ "Supported: json, table, csv"
+    end
+
+    test "--help shows long option help" do
+      output = capture_io(fn -> Cheer.run(TestLongHelp, ["--help"]) end)
+      assert output =~ "Supported: json, table, csv"
+    end
+  end
+
+  # -- Value names (#20) -------------------------------------------------------
+
+  defmodule TestValueNames do
+    use Cheer.Command
+
+    command "convert" do
+      about("Convert files")
+
+      argument(:input,
+        type: :string,
+        required: true,
+        value_name: "INPUT_FILE",
+        help: "Input path"
+      )
+
+      option(:output, type: :string, short: :o, value_name: "OUTPUT_FILE", help: "Output path")
+    end
+
+    @impl Cheer.Command
+    def run(args, _raw), do: {:ok, args}
+  end
+
+  describe "value names" do
+    test "value_name appears in argument help" do
+      output = capture_io(fn -> Cheer.run(TestValueNames, ["--help"]) end)
+      assert output =~ "<INPUT_FILE>"
+    end
+
+    test "value_name appears in option help" do
+      output = capture_io(fn -> Cheer.run(TestValueNames, ["--help"]) end)
+      assert output =~ "<OUTPUT_FILE>"
+    end
+
+    test "value_name appears in usage line" do
+      output = capture_io(fn -> Cheer.run(TestValueNames, ["--help"]) end)
+      assert output =~ "Usage: convert <INPUT_FILE>"
+    end
+  end
+
+  # -- Before/after help text (#16) --------------------------------------------
+
+  defmodule TestHelpText do
+    use Cheer.Command
+
+    command "mytool" do
+      about("A tool")
+      before_help("MyTool v1.0 -- the best tool")
+      after_help("EXAMPLES:\n  mytool --verbose input.txt")
+
+      option(:verbose, type: :boolean, help: "Verbose")
+    end
+
+    @impl Cheer.Command
+    def run(args, _raw), do: {:ok, args}
+  end
+
+  describe "before/after help text" do
+    test "before_help appears at the top" do
+      output = capture_io(fn -> Cheer.run(TestHelpText, ["--help"]) end)
+      assert output =~ "MyTool v1.0 -- the best tool"
+      # before_help should come before usage
+      [before_pos] = Regex.run(~r/MyTool v1.0/, output, return: :index)
+      [usage_pos] = Regex.run(~r/Usage:/, output, return: :index)
+      assert elem(before_pos, 0) < elem(usage_pos, 0)
+    end
+
+    test "after_help appears at the bottom" do
+      output = capture_io(fn -> Cheer.run(TestHelpText, ["--help"]) end)
+      assert output =~ "EXAMPLES:"
+      assert output =~ "mytool --verbose input.txt"
+      # after_help should come after --help line
+      [help_pos] = Regex.run(~r/Print help/, output, return: :index)
+      [after_pos] = Regex.run(~r/EXAMPLES:/, output, return: :index)
+      assert elem(after_pos, 0) > elem(help_pos, 0)
+    end
+  end
+
+  # -- Global options (#13) ----------------------------------------------------
+
+  defmodule TestGlobalChild do
+    use Cheer.Command
+
+    command "deploy" do
+      about("Deploy the app")
+      option(:target, type: :string, required: true, help: "Deploy target")
+    end
+
+    @impl Cheer.Command
+    def run(args, _raw), do: {:ok, args}
+  end
+
+  defmodule TestGlobalRoot do
+    use Cheer.Command
+
+    command "app" do
+      about("App with global options")
+
+      option(:verbose, type: :boolean, short: :v, global: true, help: "Verbose output")
+      option(:config, type: :string, global: true, default: "config.toml", help: "Config file")
+
+      subcommand(CheerTest.TestGlobalChild)
+    end
+  end
+
+  describe "global options" do
+    test "global option available in subcommand" do
+      assert {:ok, %{verbose: true, target: "prod"}} =
+               Cheer.run(TestGlobalRoot, ["deploy", "--verbose", "--target", "prod"])
+    end
+
+    test "global option default inherited" do
+      assert {:ok, %{config: "config.toml", target: "prod"}} =
+               Cheer.run(TestGlobalRoot, ["deploy", "--target", "prod"])
+    end
+
+    test "global option overridden in subcommand" do
+      assert {:ok, %{config: "custom.toml", target: "prod"}} =
+               Cheer.run(TestGlobalRoot, [
+                 "deploy",
+                 "--config",
+                 "custom.toml",
+                 "--target",
+                 "prod"
+               ])
+    end
+
+    test "global option shown in subcommand help" do
+      output = capture_io(fn -> Cheer.run(TestGlobalRoot, ["deploy", "--help"]) end)
+      assert output =~ "verbose"
+      assert output =~ "config"
+      assert output =~ "target"
+    end
+
+    test "global option not duplicated if subcommand has same name" do
+      output = capture_io(fn -> Cheer.run(TestGlobalRoot, ["deploy", "--help"]) end)
+      assert output =~ "verbose"
+    end
+  end
 end


### PR DESCRIPTION
Supersedes #28 (rebased cleanly on current main after #5 and #7 merged).

## Summary

Adds 6 features from the clap feature comparison analysis:

- **Hidden options/commands** (`hide: true`) -- options and arguments still parse but are omitted from help output. Closes #10
- **Subcommand aliases** (`aliases ["co", "ck"]`) -- match subcommands by alternate names, shown in help, included in typo suggestions. Closes #12
- **Long help** (`long_about`, `long_help`) -- `-h` shows short help, `--help` shows extended descriptions when available. Closes #9
- **Value names** (`value_name: "FILE"`) -- custom placeholder names in help and usage lines (e.g. `--output <FILE>`). Closes #20
- **Before/after help text** (`before_help`, `after_help`) -- custom text above and below auto-generated help. Closes #16
- **Global options** (`global: true`) -- options propagate to all subcommands, parsed and shown in subcommand help. Closes #13

Also fixes a routing bug where `tool sub --help` would show the parent's help instead of the subcommand's.

## Test plan

- [x] 27 new tests covering all 6 features
- [x] All 117 tests pass
- [x] `mix format --check-formatted` passes
- [x] `mix compile --warnings-as-errors` passes