### PR TITLE
feat: add display_order and help_heading

### DIFF
--- a/lib/cheer/command.ex
+++ b/lib/cheer/command.ex
@@ -46,6 +46,7 @@ defmodule Cheer.Command do
       Module.register_attribute(__MODULE__, :cheer_usage, accumulate: false)
       Module.register_attribute(__MODULE__, :cheer_subcommand_required, accumulate: false)
       Module.register_attribute(__MODULE__, :cheer_propagate_version, accumulate: false)
+      Module.register_attribute(__MODULE__, :cheer_display_order, accumulate: false)
       Module.register_attribute(__MODULE__, :cheer_trailing_var_arg, accumulate: false)
       Module.register_attribute(__MODULE__, :cheer_arguments, accumulate: true)
       Module.register_attribute(__MODULE__, :cheer_options, accumulate: true)

--- a/lib/cheer/command/compiler.ex
+++ b/lib/cheer/command/compiler.ex
@@ -15,6 +15,7 @@ defmodule Cheer.Command.Compiler do
     usage = Module.get_attribute(env.module, :cheer_usage)
     subcommand_required = Module.get_attribute(env.module, :cheer_subcommand_required) || false
     propagate_version = Module.get_attribute(env.module, :cheer_propagate_version) || false
+    display_order = Module.get_attribute(env.module, :cheer_display_order)
     trailing_var_arg = Module.get_attribute(env.module, :cheer_trailing_var_arg)
     arguments = Module.get_attribute(env.module, :cheer_arguments) |> Enum.reverse()
     options = Module.get_attribute(env.module, :cheer_options) |> Enum.reverse()
@@ -92,6 +93,7 @@ defmodule Cheer.Command.Compiler do
           usage: unquote(usage),
           subcommand_required: unquote(subcommand_required),
           propagate_version: unquote(propagate_version),
+          display_order: unquote(display_order),
           trailing_var_arg: unquote(Macro.escape(trailing_var_arg)),
           arguments: unquote(arguments_expr),
           options: unquote(options_expr),

--- a/lib/cheer/command/dsl.ex
+++ b/lib/cheer/command/dsl.ex
@@ -49,6 +49,14 @@ defmodule Cheer.Command.DSL do
   defmacro propagate_version(val), do: quote(do: @cheer_propagate_version(unquote(val)))
 
   @doc """
+  Set this command's display order as a subcommand in its parent's help output.
+
+  Lower numbers appear first. Commands without an explicit order fall back to
+  declaration order in the parent.
+  """
+  defmacro display_order(n), do: quote(do: @cheer_display_order(unquote(n)))
+
+  @doc """
   Declare a named trailing variable argument.
 
   Everything after the last declared positional (or after `--`) is collected
@@ -79,6 +87,7 @@ defmodule Cheer.Command.DSL do
     * `:long_help` - extended help text shown by `--help` (long form)
     * `:value_name` - placeholder name in help (e.g. `"FILE"`)
     * `:hide` - `true` to hide from help output
+    * `:display_order` - integer controlling position in help (lower first)
     * `:validate` - `fn value -> :ok | {:error, msg} end`
   """
   defmacro argument(name, opts \\ []) do
@@ -117,6 +126,8 @@ defmodule Cheer.Command.DSL do
     * `:hide` - `true` to hide from help output
     * `:global` - `true` to propagate to all subcommands
     * `:aliases` - list of alternative long names (e.g. `[:colour]` for `:color`)
+    * `:display_order` - integer controlling position within its help section (lower first)
+    * `:help_heading` - string; options sharing a heading are grouped under it in help
     * `:validate` - `fn value -> :ok | {:error, msg} end`
 
   Boolean options automatically support `--no-<name>` negation (e.g. `--no-color`).

--- a/lib/cheer/help.ex
+++ b/lib/cheer/help.ex
@@ -47,10 +47,12 @@ defmodule Cheer.Help do
     end
 
     visible_subcommands =
-      Enum.reject(meta.subcommands, fn sub ->
+      meta.subcommands
+      |> Enum.reject(fn sub ->
         sub_meta = sub.__cheer_meta__()
         Map.get(sub_meta, :hide, false)
       end)
+      |> sort_subcommands()
 
     if visible_subcommands != [] do
       IO.puts("COMMANDS:")
@@ -66,9 +68,11 @@ defmodule Cheer.Help do
     end
 
     visible_arguments =
-      Enum.reject(meta.arguments, fn {_name, arg_opts} ->
+      meta.arguments
+      |> Enum.reject(fn {_name, arg_opts} ->
         Keyword.get(arg_opts, :hide, false)
       end)
+      |> sort_by_display_order()
 
     has_trailing = meta[:trailing_var_arg] != nil
 
@@ -111,70 +115,19 @@ defmodule Cheer.Help do
       end)
 
     if visible_options != [] do
-      IO.puts("OPTIONS:")
+      {default_section, headed_sections} = group_options_by_heading(visible_options)
 
-      for {name, opt_opts} <- visible_options do
-        short =
-          if Keyword.has_key?(opt_opts, :short),
-            do: "-#{Keyword.get(opt_opts, :short)}, ",
-            else: "    "
-
-        help = pick_help(opt_opts, long)
-
-        type = Keyword.get(opt_opts, :type, :string)
-
-        flag_name =
-          if type == :boolean, do: "[no-]#{name}", else: to_string(name)
-
-        opt_aliases = Keyword.get(opt_opts, :aliases, [])
-
-        flag_name =
-          if opt_aliases != [] do
-            alias_str = Enum.map_join(opt_aliases, ", ", &"--#{&1}")
-            "#{flag_name} (#{alias_str})"
-          else
-            flag_name
-          end
-
-        value_suffix =
-          case Keyword.get(opt_opts, :value_name) do
-            nil -> ""
-            vn -> " <#{vn}>"
-          end
-
-        suffixes =
-          []
-          |> maybe_append(Keyword.get(opt_opts, :choices), fn choices ->
-            "[choices: #{Enum.join(choices, ", ")}]"
-          end)
-          |> maybe_append(Keyword.get(opt_opts, :default), fn default ->
-            "[default: #{default}]"
-          end)
-          |> maybe_append(Keyword.get(opt_opts, :env), fn env ->
-            "[env: #{env}]"
-          end)
-
-        suffixes =
-          if type == :count, do: suffixes ++ ["(repeatable)"], else: suffixes
-
-        suffixes =
-          if Keyword.get(opt_opts, :multi, false),
-            do: suffixes ++ ["(multiple)"],
-            else: suffixes
-
-        suffixes =
-          if Keyword.get(opt_opts, :global, false),
-            do: suffixes ++ ["(global)"],
-            else: suffixes
-
-        suffix = if suffixes != [], do: " " <> Enum.join(suffixes, " "), else: ""
-
-        IO.puts(
-          "  #{short}--#{String.pad_trailing(flag_name <> value_suffix, 16)} #{help}#{suffix}"
-        )
+      if default_section != [] do
+        IO.puts("OPTIONS:")
+        for opt <- default_section, do: IO.puts(format_option(opt, long))
+        IO.puts("")
       end
 
-      IO.puts("")
+      for {heading, opts_in_heading} <- headed_sections do
+        IO.puts("#{String.upcase(heading)}:")
+        for opt <- opts_in_heading, do: IO.puts(format_option(opt, long))
+        IO.puts("")
+      end
     end
 
     groups = Map.get(meta, :groups, %{})
@@ -216,6 +169,103 @@ defmodule Cheer.Help do
 
   defp maybe_append(list, nil, _fun), do: list
   defp maybe_append(list, value, fun), do: list ++ [fun.(value)]
+
+  defp sort_by_display_order(items) do
+    items
+    |> Enum.with_index()
+    |> Enum.sort_by(fn {{_name, opts}, idx} ->
+      {Keyword.get(opts, :display_order) || 1_000_000, idx}
+    end)
+    |> Enum.map(&elem(&1, 0))
+  end
+
+  defp sort_subcommands(subs) do
+    subs
+    |> Enum.with_index()
+    |> Enum.sort_by(fn {sub, idx} ->
+      order = Map.get(sub.__cheer_meta__(), :display_order) || 1_000_000
+      {order, idx}
+    end)
+    |> Enum.map(&elem(&1, 0))
+  end
+
+  defp group_options_by_heading(options) do
+    {defaults, headed} =
+      Enum.split_with(options, fn {_, opts} -> is_nil(Keyword.get(opts, :help_heading)) end)
+
+    sorted_defaults = sort_by_display_order(defaults)
+
+    # Preserve first-appearance order of headings, then sort within each.
+    {heading_order, grouped} =
+      Enum.reduce(headed, {[], %{}}, fn {_, opts} = item, {order, acc} ->
+        heading = Keyword.get(opts, :help_heading)
+        new_order = if heading in order, do: order, else: order ++ [heading]
+        new_acc = Map.update(acc, heading, [item], fn existing -> existing ++ [item] end)
+        {new_order, new_acc}
+      end)
+
+    headed_sections =
+      Enum.map(heading_order, fn heading ->
+        {heading, sort_by_display_order(grouped[heading])}
+      end)
+
+    {sorted_defaults, headed_sections}
+  end
+
+  defp format_option({name, opt_opts}, long) do
+    short =
+      if Keyword.has_key?(opt_opts, :short),
+        do: "-#{Keyword.get(opt_opts, :short)}, ",
+        else: "    "
+
+    help = pick_help(opt_opts, long)
+    type = Keyword.get(opt_opts, :type, :string)
+
+    base_flag = if type == :boolean, do: "[no-]#{name}", else: to_string(name)
+    opt_aliases = Keyword.get(opt_opts, :aliases, [])
+
+    flag_name =
+      if opt_aliases != [] do
+        alias_str = Enum.map_join(opt_aliases, ", ", &"--#{&1}")
+        "#{base_flag} (#{alias_str})"
+      else
+        base_flag
+      end
+
+    value_suffix =
+      case Keyword.get(opt_opts, :value_name) do
+        nil -> ""
+        vn -> " <#{vn}>"
+      end
+
+    suffixes =
+      []
+      |> maybe_append(Keyword.get(opt_opts, :choices), fn choices ->
+        "[choices: #{Enum.join(choices, ", ")}]"
+      end)
+      |> maybe_append(Keyword.get(opt_opts, :default), fn default ->
+        "[default: #{default}]"
+      end)
+      |> maybe_append(Keyword.get(opt_opts, :env), fn env ->
+        "[env: #{env}]"
+      end)
+
+    suffixes = if type == :count, do: suffixes ++ ["(repeatable)"], else: suffixes
+
+    suffixes =
+      if Keyword.get(opt_opts, :multi, false),
+        do: suffixes ++ ["(multiple)"],
+        else: suffixes
+
+    suffixes =
+      if Keyword.get(opt_opts, :global, false),
+        do: suffixes ++ ["(global)"],
+        else: suffixes
+
+    suffix = if suffixes != [], do: " " <> Enum.join(suffixes, " "), else: ""
+
+    "  #{short}--#{String.pad_trailing(flag_name <> value_suffix, 16)} #{help}#{suffix}"
+  end
 
   defp format_usage(meta, prog) do
     parts = ["Usage: #{prog}"]

--- a/test/cheer_test.exs
+++ b/test/cheer_test.exs
@@ -1421,4 +1421,184 @@ defmodule CheerTest do
                Cheer.run(TestTrailingRequired, ["a.txt", "b.txt"])
     end
   end
+
+  # -- display_order and help_heading -----------------------------------------
+
+  defmodule TestDisplayOrderOpts do
+    use Cheer.Command
+
+    command "ordered" do
+      about("Options with display_order")
+
+      option(:zulu, type: :string, help: "Z opt", display_order: 1)
+      option(:alpha, type: :string, help: "A opt", display_order: 2)
+      option(:middle, type: :string, help: "M opt")
+    end
+
+    @impl Cheer.Command
+    def run(args, _raw), do: {:ok, args}
+  end
+
+  defmodule TestDisplayOrderArgs do
+    use Cheer.Command
+
+    command "ordered-args" do
+      about("Arguments with display_order")
+
+      argument(:second, type: :string, help: "Shown second", display_order: 2)
+      argument(:first, type: :string, help: "Shown first", display_order: 1)
+    end
+
+    @impl Cheer.Command
+    def run(args, _raw), do: {:ok, args}
+  end
+
+  defmodule TestSubAlpha do
+    use Cheer.Command
+
+    command "alpha" do
+      about("Alpha sub")
+      display_order(2)
+    end
+
+    @impl Cheer.Command
+    def run(args, _raw), do: {:ok, args}
+  end
+
+  defmodule TestSubBeta do
+    use Cheer.Command
+
+    command "beta" do
+      about("Beta sub")
+      display_order(1)
+    end
+
+    @impl Cheer.Command
+    def run(args, _raw), do: {:ok, args}
+  end
+
+  defmodule TestSubGamma do
+    use Cheer.Command
+
+    command "gamma" do
+      about("Gamma sub")
+    end
+
+    @impl Cheer.Command
+    def run(args, _raw), do: {:ok, args}
+  end
+
+  defmodule TestDisplayOrderSubs do
+    use Cheer.Command
+
+    command "router" do
+      about("Subcommands with display_order")
+
+      subcommand(CheerTest.TestSubAlpha)
+      subcommand(CheerTest.TestSubBeta)
+      subcommand(CheerTest.TestSubGamma)
+    end
+  end
+
+  defmodule TestHelpHeading do
+    use Cheer.Command
+
+    command "headed" do
+      about("Options with custom headings")
+
+      option(:host, type: :string, help: "Hostname", help_heading: "Network")
+      option(:port, type: :integer, help: "Port", help_heading: "Network")
+      option(:user, type: :string, help: "Username", help_heading: "Auth")
+      option(:password, type: :string, help: "Password", help_heading: "Auth")
+      option(:verbose, type: :boolean, help: "Be verbose")
+    end
+
+    @impl Cheer.Command
+    def run(args, _raw), do: {:ok, args}
+  end
+
+  defmodule TestHeadingWithOrder do
+    use Cheer.Command
+
+    command "headed-ordered" do
+      about("Mixed headings and display_order")
+
+      option(:b_opt, type: :string, help: "B", help_heading: "Net", display_order: 2)
+      option(:a_opt, type: :string, help: "A", help_heading: "Net", display_order: 1)
+    end
+
+    @impl Cheer.Command
+    def run(args, _raw), do: {:ok, args}
+  end
+
+  describe "display_order for options" do
+    test "options sorted by display_order, unordered fall back to declaration order" do
+      output = capture_io(fn -> Cheer.run(TestDisplayOrderOpts, ["--help"]) end)
+      zulu_pos = :binary.match(output, "--zulu") |> elem(0)
+      alpha_pos = :binary.match(output, "--alpha") |> elem(0)
+      middle_pos = :binary.match(output, "--middle") |> elem(0)
+      assert zulu_pos < alpha_pos
+      assert alpha_pos < middle_pos
+    end
+  end
+
+  describe "display_order for arguments" do
+    test "arguments are reordered in help" do
+      output = capture_io(fn -> Cheer.run(TestDisplayOrderArgs, ["--help"]) end)
+      first_pos = :binary.match(output, "<first>") |> elem(0)
+      second_pos = :binary.match(output, "<second>") |> elem(0)
+      assert first_pos < second_pos
+    end
+  end
+
+  describe "display_order for subcommands" do
+    test "subcommands sorted by their declared display_order" do
+      output = capture_io(fn -> Cheer.run(TestDisplayOrderSubs, ["--help"]) end)
+      beta_pos = :binary.match(output, "beta") |> elem(0)
+      alpha_pos = :binary.match(output, "alpha") |> elem(0)
+      gamma_pos = :binary.match(output, "gamma") |> elem(0)
+      assert beta_pos < alpha_pos
+      assert alpha_pos < gamma_pos
+    end
+  end
+
+  describe "help_heading for options" do
+    test "options grouped under custom headings" do
+      output = capture_io(fn -> Cheer.run(TestHelpHeading, ["--help"]) end)
+      assert output =~ "OPTIONS:"
+      assert output =~ "NETWORK:"
+      assert output =~ "AUTH:"
+    end
+
+    test "default section appears before custom heading sections" do
+      output = capture_io(fn -> Cheer.run(TestHelpHeading, ["--help"]) end)
+      options_pos = :binary.match(output, "OPTIONS:") |> elem(0)
+      network_pos = :binary.match(output, "NETWORK:") |> elem(0)
+      assert options_pos < network_pos
+    end
+
+    test "first-appearance order of headings is preserved" do
+      output = capture_io(fn -> Cheer.run(TestHelpHeading, ["--help"]) end)
+      network_pos = :binary.match(output, "NETWORK:") |> elem(0)
+      auth_pos = :binary.match(output, "AUTH:") |> elem(0)
+      assert network_pos < auth_pos
+    end
+
+    test "options under a heading are listed under it (not in default)" do
+      output = capture_io(fn -> Cheer.run(TestHelpHeading, ["--help"]) end)
+      # --host should appear after NETWORK: and before AUTH:
+      network_pos = :binary.match(output, "NETWORK:") |> elem(0)
+      host_pos = :binary.match(output, "--host") |> elem(0)
+      auth_pos = :binary.match(output, "AUTH:") |> elem(0)
+      assert network_pos < host_pos
+      assert host_pos < auth_pos
+    end
+
+    test "display_order applies within a heading section" do
+      output = capture_io(fn -> Cheer.run(TestHeadingWithOrder, ["--help"]) end)
+      a_pos = :binary.match(output, "--a_opt") |> elem(0)
+      b_pos = :binary.match(output, "--b_opt") |> elem(0)
+      assert a_pos < b_pos
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- Adds `:display_order` opt to `option` and `argument` macros, plus a top-level `display_order/1` macro for ordering subcommands. Help output sorts items accordingly with declaration order as the stable tiebreaker.
- Adds `:help_heading` opt to `option`. Options sharing a heading are grouped under their own section in help; unheaded options appear in the default `OPTIONS:` section first. Heading sections preserve first-appearance order, and `display_order` applies within each section.

Closes #15
Closes #14

## Test plan
- [x] `mix format --check-formatted`
- [x] `mix compile --warnings-as-errors`
- [x] `mix credo --strict`
- [x] `mix test` (142 tests, 0 failures -- 8 new)
- [x] `mix dialyzer`