### PR TITLE
feat: infer subcommands from unique prefixes

### DIFF
--- a/lib/cheer/command.ex
+++ b/lib/cheer/command.ex
@@ -46,6 +46,7 @@ defmodule Cheer.Command do
       Module.register_attribute(__MODULE__, :cheer_usage, accumulate: false)
       Module.register_attribute(__MODULE__, :cheer_subcommand_required, accumulate: false)
       Module.register_attribute(__MODULE__, :cheer_propagate_version, accumulate: false)
+      Module.register_attribute(__MODULE__, :cheer_infer_subcommands, accumulate: false)
       Module.register_attribute(__MODULE__, :cheer_display_order, accumulate: false)
       Module.register_attribute(__MODULE__, :cheer_trailing_var_arg, accumulate: false)
       Module.register_attribute(__MODULE__, :cheer_arguments, accumulate: true)

--- a/lib/cheer/command/compiler.ex
+++ b/lib/cheer/command/compiler.ex
@@ -15,6 +15,7 @@ defmodule Cheer.Command.Compiler do
     usage = Module.get_attribute(env.module, :cheer_usage)
     subcommand_required = Module.get_attribute(env.module, :cheer_subcommand_required) || false
     propagate_version = Module.get_attribute(env.module, :cheer_propagate_version) || false
+    infer_subcommands = Module.get_attribute(env.module, :cheer_infer_subcommands) || false
     display_order = Module.get_attribute(env.module, :cheer_display_order)
     trailing_var_arg = Module.get_attribute(env.module, :cheer_trailing_var_arg)
     arguments = Module.get_attribute(env.module, :cheer_arguments) |> Enum.reverse()
@@ -93,6 +94,7 @@ defmodule Cheer.Command.Compiler do
           usage: unquote(usage),
           subcommand_required: unquote(subcommand_required),
           propagate_version: unquote(propagate_version),
+          infer_subcommands: unquote(infer_subcommands),
           display_order: unquote(display_order),
           trailing_var_arg: unquote(Macro.escape(trailing_var_arg)),
           arguments: unquote(arguments_expr),

--- a/lib/cheer/command/dsl.ex
+++ b/lib/cheer/command/dsl.ex
@@ -49,6 +49,16 @@ defmodule Cheer.Command.DSL do
   defmacro propagate_version(val), do: quote(do: @cheer_propagate_version(unquote(val)))
 
   @doc """
+  Allow matching subcommands from unambiguous name prefixes.
+
+  When enabled, `che` will resolve to `checkout` if no other subcommand starts
+  with `che`. Ambiguous prefixes produce an error listing the candidates.
+  Exact matches always take precedence over prefix inference. Matching is
+  done against canonical names only -- aliases are not prefix-matched.
+  """
+  defmacro infer_subcommands(val), do: quote(do: @cheer_infer_subcommands(unquote(val)))
+
+  @doc """
   Set this command's display order as a subcommand in its parent's help output.
 
   Lower numbers appear first. Commands without an explicit order fall back to

--- a/lib/cheer/router.ex
+++ b/lib/cheer/router.ex
@@ -57,13 +57,16 @@ defmodule Cheer.Router do
 
     # If the first token matches a subcommand, dispatch to it before checking
     # flags. This ensures `tool sub --help` shows the subcommand's help.
+    infer? = Map.get(meta, :infer_subcommands, false)
+
     first_is_subcommand =
       case argv do
         [token | _] ->
-          Enum.any?(meta.subcommands, fn sub ->
-            sub_meta = sub.__cheer_meta__()
-            sub_meta.name == token or token in Map.get(sub_meta, :aliases, [])
-          end)
+          case match_subcommand(meta.subcommands, [token], infer?) do
+            {:ok, _, _} -> true
+            {:ambiguous, _, _} -> true
+            _ -> false
+          end
 
         _ ->
           false
@@ -95,10 +98,15 @@ defmodule Cheer.Router do
 
   defp resolve_help(command, [token | rest], opts) do
     meta = command.__cheer_meta__()
+    infer? = Map.get(meta, :infer_subcommands, false)
 
-    case match_subcommand(meta.subcommands, [token]) do
+    case match_subcommand(meta.subcommands, [token], infer?) do
       {:ok, sub_module, _} ->
         resolve_help(sub_module, rest, opts)
+
+      {:ambiguous, t, candidates} ->
+        print_ambiguous_subcommand(t, candidates)
+        :ok
 
       _ ->
         IO.puts("error: unknown command '#{token}'")
@@ -107,9 +115,14 @@ defmodule Cheer.Router do
   end
 
   defp dispatch_command(command, meta, argv, opts, hooks) do
-    case match_subcommand(meta.subcommands, argv) do
+    infer? = Map.get(meta, :infer_subcommands, false)
+
+    case match_subcommand(meta.subcommands, argv, infer?) do
       {:ok, sub_module, rest} ->
         dispatch_with_hooks(sub_module, rest, opts, hooks)
+
+      {:ambiguous, token, candidates} ->
+        print_ambiguous_subcommand(token, candidates)
 
       {:error, unknown_token} ->
         print_unknown_command(meta, unknown_token)
@@ -404,33 +417,58 @@ defmodule Cheer.Router do
 
   # -- Subcommand matching --
 
-  defp match_subcommand([], _argv), do: :none
+  defp match_subcommand([], _argv, _infer?), do: :none
+  defp match_subcommand(_subcommands, [], _infer?), do: :none
 
-  defp match_subcommand(subcommands, [token | rest]) do
-    found =
-      Enum.find_value(subcommands, nil, fn sub_module ->
+  defp match_subcommand(subcommands, [token | rest], infer?) do
+    exact =
+      Enum.find(subcommands, fn sub_module ->
         sub_meta = sub_module.__cheer_meta__()
-        cmd_aliases = Map.get(sub_meta, :aliases, [])
-
-        if sub_meta.name == token or token in cmd_aliases do
-          {:ok, sub_module, rest}
-        end
+        sub_meta.name == token or token in Map.get(sub_meta, :aliases, [])
       end)
 
-    case found do
-      {:ok, _, _} = match ->
-        match
+    cond do
+      exact != nil ->
+        {:ok, exact, rest}
 
-      nil ->
-        if String.starts_with?(token, "-") do
-          :none
-        else
-          {:error, token}
-        end
+      String.starts_with?(token, "-") ->
+        :none
+
+      infer? ->
+        infer_subcommand(subcommands, token, rest)
+
+      true ->
+        {:error, token}
     end
   end
 
-  defp match_subcommand(_subcommands, []), do: :none
+  defp infer_subcommand(subcommands, token, rest) do
+    candidates =
+      Enum.filter(subcommands, fn sub ->
+        String.starts_with?(sub.__cheer_meta__().name, token)
+      end)
+
+    case candidates do
+      [single] ->
+        {:ok, single, rest}
+
+      [] ->
+        {:error, token}
+
+      many ->
+        names =
+          many
+          |> Enum.map(& &1.__cheer_meta__().name)
+          |> Enum.sort()
+
+        {:ambiguous, token, names}
+    end
+  end
+
+  defp print_ambiguous_subcommand(token, candidates) do
+    IO.puts("error: '#{token}' is ambiguous")
+    IO.puts("candidates: #{Enum.join(candidates, ", ")}")
+  end
 
   # -- OptionParser spec --
 

--- a/test/cheer_test.exs
+++ b/test/cheer_test.exs
@@ -1601,4 +1601,107 @@ defmodule CheerTest do
       assert a_pos < b_pos
     end
   end
+
+  # -- infer_subcommands ------------------------------------------------------
+
+  defmodule TestInferCheckout do
+    use Cheer.Command
+
+    command "checkout" do
+      about("Check out a branch")
+    end
+
+    @impl Cheer.Command
+    def run(args, _raw), do: {:ok, {:checkout, args}}
+  end
+
+  defmodule TestInferCheck do
+    use Cheer.Command
+
+    command "check" do
+      about("Run checks")
+    end
+
+    @impl Cheer.Command
+    def run(args, _raw), do: {:ok, {:check, args}}
+  end
+
+  defmodule TestInferStatus do
+    use Cheer.Command
+
+    command "status" do
+      about("Show status")
+    end
+
+    @impl Cheer.Command
+    def run(args, _raw), do: {:ok, {:status, args}}
+  end
+
+  defmodule TestInferRoot do
+    use Cheer.Command
+
+    command "git" do
+      about("Tiny git")
+      infer_subcommands(true)
+
+      subcommand(CheerTest.TestInferCheckout)
+      subcommand(CheerTest.TestInferCheck)
+      subcommand(CheerTest.TestInferStatus)
+    end
+  end
+
+  defmodule TestNoInferRoot do
+    use Cheer.Command
+
+    command "git" do
+      about("Tiny git, no inference")
+
+      subcommand(CheerTest.TestInferCheckout)
+      subcommand(CheerTest.TestInferStatus)
+    end
+  end
+
+  describe "infer_subcommands" do
+    test "unique prefix resolves to the matching subcommand" do
+      assert {:ok, {:status, _}} = Cheer.run(TestInferRoot, ["sta"])
+    end
+
+    test "ambiguous prefix prints error and lists candidates" do
+      output = capture_io(fn -> Cheer.run(TestInferRoot, ["che"]) end)
+      assert output =~ "error: 'che' is ambiguous"
+      assert output =~ "candidates:"
+      assert output =~ "check"
+      assert output =~ "checkout"
+    end
+
+    test "exact match wins over prefix" do
+      # `check` is also a prefix of `checkout`, but exact match takes priority
+      assert {:ok, {:check, _}} = Cheer.run(TestInferRoot, ["check"])
+    end
+
+    test "non-matching prefix falls back to unknown command" do
+      output = capture_io(fn -> Cheer.run(TestInferRoot, ["xyz"]) end)
+      assert output =~ "error: unknown command 'xyz'"
+    end
+
+    test "inference is disabled by default" do
+      output = capture_io(fn -> Cheer.run(TestNoInferRoot, ["sta"]) end)
+      assert output =~ "error: unknown command 'sta'"
+    end
+
+    test "inferred subcommand still receives flags" do
+      output = capture_io(fn -> Cheer.run(TestInferRoot, ["sta", "--help"]) end)
+      assert output =~ "Show status"
+    end
+
+    test "help <prefix> resolves the inferred command" do
+      output = capture_io(fn -> Cheer.run(TestInferRoot, ["help", "sta"]) end)
+      assert output =~ "Show status"
+    end
+
+    test "help <ambiguous-prefix> reports the ambiguity" do
+      output = capture_io(fn -> Cheer.run(TestInferRoot, ["help", "che"]) end)
+      assert output =~ "is ambiguous"
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- New `infer_subcommands/1` DSL macro. When set to `true`, any unambiguous prefix of a subcommand's canonical name resolves to that subcommand.
- Exact matches (and aliases) still take priority over prefix inference.
- Ambiguous prefixes print a clear error listing the candidates.
- Inference is opt-in (disabled by default) to avoid surprising behavior.
- Aliases are not prefix-matched, only canonical names.

Both `tool <prefix> --help` and `tool help <prefix>` honor inference.

Closes #22

## Test plan
- [x] `mix format --check-formatted`
- [x] `mix compile --warnings-as-errors`
- [x] `mix credo --strict`
- [x] `mix test` (150 tests, 0 failures -- 8 new)
- [x] `mix dialyzer`