### PR TITLE
feat: per-option constraints and conditional required

### DIFF
--- a/lib/cheer/command/dsl.ex
+++ b/lib/cheer/command/dsl.ex
@@ -138,6 +138,12 @@ defmodule Cheer.Command.DSL do
     * `:aliases` - list of alternative long names (e.g. `[:colour]` for `:color`)
     * `:display_order` - integer controlling position within its help section (lower first)
     * `:help_heading` - string; options sharing a heading are grouped under it in help
+    * `:conflicts_with` - atom or list of atoms; this option cannot be used with the named option(s)
+    * `:requires` - atom or list of atoms; the named option(s) must also be present
+    * `:required_if` - keyword list `[other_opt: value]`; this option is required when
+      any pair matches (i.e. `args[other_opt] == value`)
+    * `:required_unless` - atom or list of atoms; this option is required unless any
+      of the named options are present
     * `:validate` - `fn value -> :ok | {:error, msg} end`
 
   Boolean options automatically support `--no-<name>` negation (e.g. `--no-color`).

--- a/lib/cheer/router.ex
+++ b/lib/cheer/router.ex
@@ -231,7 +231,9 @@ defmodule Cheer.Router do
           :handled
 
         true ->
-          with :ok <- validate_groups(args, Map.get(meta, :groups, %{})),
+          with :ok <- validate_conditional_required(args, all_options),
+               :ok <- validate_constraints(args, all_options),
+               :ok <- validate_groups(args, Map.get(meta, :groups, %{})),
                :ok <- validate_params(args, all_options),
                :ok <- run_validators(args, Map.get(meta, :validators, [])) do
             {:ok, args}
@@ -263,6 +265,109 @@ defmodule Cheer.Router do
     end)
     |> Enum.map(fn {name, _o} -> name end)
   end
+
+  # -- Conditional required (required_if / required_unless) --
+
+  defp validate_conditional_required(args, options) do
+    Enum.reduce_while(options, :ok, fn {name, opts}, _acc ->
+      if Map.has_key?(args, name) do
+        {:cont, :ok}
+      else
+        check_conditional_required(name, opts, args)
+      end
+    end)
+  end
+
+  defp check_conditional_required(name, opts, args) do
+    cond do
+      Keyword.has_key?(opts, :required_if) ->
+        case match_required_if(Keyword.fetch!(opts, :required_if), args) do
+          {:match, dep, val} ->
+            {:halt,
+             {:error, "--#{name} is required when --#{dep} is #{format_required_value(val)}"}}
+
+          :no_match ->
+            {:cont, :ok}
+        end
+
+      Keyword.has_key?(opts, :required_unless) ->
+        deps = Keyword.fetch!(opts, :required_unless)
+
+        if any_present?(deps, args) do
+          {:cont, :ok}
+        else
+          {:halt, {:error, "--#{name} is required unless #{format_dep_list(deps)} is provided"}}
+        end
+
+      true ->
+        {:cont, :ok}
+    end
+  end
+
+  defp match_required_if(checks, args) when is_list(checks) do
+    Enum.find_value(checks, :no_match, fn {dep, expected} ->
+      case Map.fetch(args, dep) do
+        {:ok, ^expected} -> {:match, dep, expected}
+        _ -> nil
+      end
+    end)
+  end
+
+  defp any_present?(name, args) when is_atom(name), do: Map.has_key?(args, name)
+
+  defp any_present?(names, args) when is_list(names),
+    do: Enum.any?(names, &Map.has_key?(args, &1))
+
+  defp format_dep_list(name) when is_atom(name), do: "--#{name}"
+
+  defp format_dep_list(names) when is_list(names),
+    do: Enum.map_join(names, ", ", &"--#{&1}")
+
+  defp format_required_value(val) when is_binary(val), do: "'#{val}'"
+  defp format_required_value(val), do: inspect(val)
+
+  # -- Per-option constraints (conflicts_with / requires) --
+
+  defp validate_constraints(args, options) do
+    Enum.reduce_while(options, :ok, fn {name, opts}, _acc ->
+      if Map.has_key?(args, name) do
+        check_constraints(name, opts, args)
+      else
+        {:cont, :ok}
+      end
+    end)
+  end
+
+  defp check_constraints(name, opts, args) do
+    with :ok <- check_conflicts(name, opts, args),
+         :ok <- check_requires(name, opts, args) do
+      {:cont, :ok}
+    else
+      err -> {:halt, err}
+    end
+  end
+
+  defp check_conflicts(name, opts, args) do
+    conflicts = list_of(Keyword.get(opts, :conflicts_with))
+
+    case Enum.find(conflicts, &Map.has_key?(args, &1)) do
+      nil -> :ok
+      other -> {:error, "--#{name} cannot be used with --#{other}"}
+    end
+  end
+
+  defp check_requires(name, opts, args) do
+    requires = list_of(Keyword.get(opts, :requires))
+
+    case Enum.find(requires, &(not Map.has_key?(args, &1))) do
+      nil -> :ok
+      other -> {:error, "--#{name} requires --#{other}"}
+    end
+  end
+
+  defp list_of(nil), do: []
+  defp list_of(atom) when is_atom(atom), do: [atom]
+  defp list_of(list) when is_list(list), do: list
 
   # -- Groups validation --
 

--- a/test/cheer_test.exs
+++ b/test/cheer_test.exs
@@ -1704,4 +1704,230 @@ defmodule CheerTest do
       assert output =~ "is ambiguous"
     end
   end
+
+  # -- conflicts_with / requires ----------------------------------------------
+
+  defmodule TestConflicts do
+    use Cheer.Command
+
+    command "conflicts" do
+      about("Test conflicts_with")
+
+      option(:json, type: :boolean, conflicts_with: :yaml, help: "JSON output")
+      option(:yaml, type: :boolean, help: "YAML output")
+    end
+
+    @impl Cheer.Command
+    def run(args, _raw), do: {:ok, args}
+  end
+
+  defmodule TestConflictsList do
+    use Cheer.Command
+
+    command "conflicts-list" do
+      about("Test conflicts_with as a list")
+
+      option(:json, type: :boolean, conflicts_with: [:yaml, :toml])
+      option(:yaml, type: :boolean)
+      option(:toml, type: :boolean)
+    end
+
+    @impl Cheer.Command
+    def run(args, _raw), do: {:ok, args}
+  end
+
+  defmodule TestRequires do
+    use Cheer.Command
+
+    command "requires" do
+      about("Test requires")
+
+      option(:user, type: :string, requires: :password, help: "User")
+      option(:password, type: :string, help: "Password")
+    end
+
+    @impl Cheer.Command
+    def run(args, _raw), do: {:ok, args}
+  end
+
+  defmodule TestRequiresList do
+    use Cheer.Command
+
+    command "requires-list" do
+      about("Test requires as a list")
+
+      option(:deploy, type: :boolean, requires: [:env, :region])
+      option(:env, type: :string)
+      option(:region, type: :string)
+    end
+
+    @impl Cheer.Command
+    def run(args, _raw), do: {:ok, args}
+  end
+
+  describe "conflicts_with" do
+    test "succeeds when only one of the conflicting options is set" do
+      assert {:ok, %{json: true}} = Cheer.run(TestConflicts, ["--json"])
+      assert {:ok, %{yaml: true}} = Cheer.run(TestConflicts, ["--yaml"])
+    end
+
+    test "errors when both conflicting options are set" do
+      output = capture_io(fn -> Cheer.run(TestConflicts, ["--json", "--yaml"]) end)
+      assert output =~ "error: --json cannot be used with --yaml"
+    end
+
+    test "succeeds when neither is set" do
+      assert {:ok, _} = Cheer.run(TestConflicts, [])
+    end
+
+    test "list form errors on first conflict found" do
+      output = capture_io(fn -> Cheer.run(TestConflictsList, ["--json", "--toml"]) end)
+      assert output =~ "error: --json cannot be used with --toml"
+    end
+
+    test "list form succeeds when no conflicts present" do
+      assert {:ok, _} = Cheer.run(TestConflictsList, ["--json"])
+    end
+  end
+
+  describe "requires" do
+    test "succeeds when both required options are present" do
+      assert {:ok, %{user: "alice", password: "secret"}} =
+               Cheer.run(TestRequires, ["--user", "alice", "--password", "secret"])
+    end
+
+    test "errors when option is set without its dependency" do
+      output = capture_io(fn -> Cheer.run(TestRequires, ["--user", "alice"]) end)
+      assert output =~ "error: --user requires --password"
+    end
+
+    test "succeeds when neither option is set" do
+      assert {:ok, _} = Cheer.run(TestRequires, [])
+    end
+
+    test "list form errors when any required option is missing" do
+      output = capture_io(fn -> Cheer.run(TestRequiresList, ["--deploy", "--env", "prod"]) end)
+      assert output =~ "error: --deploy requires --region"
+    end
+
+    test "list form succeeds when all required options are present" do
+      assert {:ok, _} =
+               Cheer.run(TestRequiresList, ["--deploy", "--env", "prod", "--region", "us-east"])
+    end
+  end
+
+  # -- required_if / required_unless ------------------------------------------
+
+  defmodule TestRequiredIf do
+    use Cheer.Command
+
+    command "req-if" do
+      about("Test required_if")
+
+      option(:format, type: :string, choices: ["json", "table", "raw"], help: "Format")
+      option(:output, type: :string, required_if: [format: "json"], help: "Output file")
+    end
+
+    @impl Cheer.Command
+    def run(args, _raw), do: {:ok, args}
+  end
+
+  defmodule TestRequiredIfMulti do
+    use Cheer.Command
+
+    command "req-if-multi" do
+      about("Test required_if with multiple conditions")
+
+      option(:mode, type: :string, choices: ["dev", "prod", "test"])
+      option(:env, type: :string)
+      option(:secret, type: :string, required_if: [mode: "prod", env: "live"])
+    end
+
+    @impl Cheer.Command
+    def run(args, _raw), do: {:ok, args}
+  end
+
+  defmodule TestRequiredUnless do
+    use Cheer.Command
+
+    command "req-unless" do
+      about("Test required_unless")
+
+      option(:config, type: :string, required_unless: :inline, help: "Config file")
+      option(:inline, type: :boolean, help: "Use inline config")
+    end
+
+    @impl Cheer.Command
+    def run(args, _raw), do: {:ok, args}
+  end
+
+  defmodule TestRequiredUnlessList do
+    use Cheer.Command
+
+    command "req-unless-list" do
+      about("Test required_unless as a list")
+
+      option(:input, type: :string, required_unless: [:stdin, :url])
+      option(:stdin, type: :boolean)
+      option(:url, type: :string)
+    end
+
+    @impl Cheer.Command
+    def run(args, _raw), do: {:ok, args}
+  end
+
+  describe "required_if" do
+    test "not required when condition does not hold" do
+      assert {:ok, _} = Cheer.run(TestRequiredIf, ["--format", "table"])
+    end
+
+    test "required when condition holds and missing" do
+      output = capture_io(fn -> Cheer.run(TestRequiredIf, ["--format", "json"]) end)
+      assert output =~ "error: --output is required when --format is 'json'"
+    end
+
+    test "succeeds when condition holds and option provided" do
+      assert {:ok, _} =
+               Cheer.run(TestRequiredIf, ["--format", "json", "--output", "out.json"])
+    end
+
+    test "not required when neither condition option is set" do
+      assert {:ok, _} = Cheer.run(TestRequiredIf, [])
+    end
+
+    test "fires on the first matching condition in a multi-pair list" do
+      output = capture_io(fn -> Cheer.run(TestRequiredIfMulti, ["--mode", "prod"]) end)
+      assert output =~ "error: --secret is required when --mode is 'prod'"
+    end
+
+    test "fires when only the second condition matches" do
+      output = capture_io(fn -> Cheer.run(TestRequiredIfMulti, ["--env", "live"]) end)
+      assert output =~ "error: --secret is required when --env is 'live'"
+    end
+  end
+
+  describe "required_unless" do
+    test "errors when option missing and dependency absent" do
+      output = capture_io(fn -> Cheer.run(TestRequiredUnless, []) end)
+      assert output =~ "error: --config is required unless --inline is provided"
+    end
+
+    test "succeeds when dependency is present" do
+      assert {:ok, _} = Cheer.run(TestRequiredUnless, ["--inline"])
+    end
+
+    test "succeeds when option itself is present" do
+      assert {:ok, _} = Cheer.run(TestRequiredUnless, ["--config", "app.conf"])
+    end
+
+    test "list form requires any one of the dependencies" do
+      assert {:ok, _} = Cheer.run(TestRequiredUnlessList, ["--stdin"])
+      assert {:ok, _} = Cheer.run(TestRequiredUnlessList, ["--url", "http://x"])
+    end
+
+    test "list form errors when none of the dependencies are present" do
+      output = capture_io(fn -> Cheer.run(TestRequiredUnlessList, []) end)
+      assert output =~ "error: --input is required unless --stdin, --url is provided"
+    end
+  end
 end


### PR DESCRIPTION
## Summary
Adds four clap-parity option keys, all enforced in the router's validation pipeline. No DSL macros or compile-time changes -- they're just new keys on `option`.

**`:conflicts_with`** -- atom or list. Errors if this option is set alongside any of the named option(s). _Closes #19_
**`:requires`** -- atom or list. Errors if this option is set without any named dependency. _Closes #19_
**`:required_if`** -- keyword list `[other: value, ...]`. Errors if any pair matches and this option is missing. Strings render quoted, other types via `inspect`. _Closes #18_
**`:required_unless`** -- atom or list. Errors if this option is missing AND none of the named options are present. _Closes #18_

Pipeline order: `conditional_required -> constraints -> groups -> per-param validate -> cross-param validators`. Single-option errors fire before group errors.

## Test plan
- [x] `mix format --check-formatted`
- [x] `mix compile --warnings-as-errors`
- [x] `mix credo --strict`
- [x] `mix test` (171 tests, 0 failures -- 21 new)
- [x] `mix dialyzer`