### PR TITLE
chore: release readiness for 0.1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,13 @@ A clap-inspired CLI framework for Elixir. Define your command tree once and get 
 - **Arbitrary nesting** -- subcommand trees of any depth
 - **Typed options and arguments** -- `:string`, `:integer`, `:float`, `:boolean` with automatic coercion
 - **Validation** -- per-param (`:validate`, `:choices`), cross-param (`validate/1`), required fields
+- **Conditional required** -- `:required_if` and `:required_unless` for inter-option dependencies
+- **Per-option constraints** -- `:conflicts_with` and `:requires` for relational rules
 - **Environment variable fallback** -- `option :port, env: "MY_PORT"`
 - **Param groups** -- mutually exclusive and co-occurring option groups
 - **Lifecycle hooks** -- `before_run`, `after_run`, `persistent_before_run` (inherited by children)
-- **Auto-generated help** -- includes defaults, env vars, choices, groups
+- **Auto-generated help** -- defaults, env vars, choices, groups, custom headings, ordering
+- **Subcommand prefix inference** -- `infer_subcommands true` resolves unambiguous prefixes
 - **Shell completion** -- bash, zsh, and fish script generation
 - **REPL mode** -- interactive command shell from the same command tree
 - **In-process test runner** -- `Cheer.Test.run/3` captures output and return values
@@ -52,7 +55,7 @@ Cheer.run(MyApp.CLI.Greet, ["world", "--loud"], prog: "greet")
 ```elixir
 # Per-param: inline function
 option :port, type: :integer,
-  validate: fn p -> if p in 1024..65535, do: :ok, else: {:error, "invalid port"} end
+  validate: fn p -> if p in 1024..65_535, do: :ok, else: {:error, "invalid port"} end
 
 # Per-param: choices
 option :format, type: :string, choices: ["json", "csv", "table"]
@@ -61,6 +64,26 @@ option :format, type: :string, choices: ["json", "csv", "table"]
 validate fn args ->
   if args[:tls] && !args[:cert], do: {:error, "--tls requires --cert"}, else: :ok
 end
+```
+
+## Conditional Required and Per-Option Constraints
+
+```elixir
+# Required only when another option holds a particular value
+option :format, type: :string, choices: ["json", "table"]
+option :output, type: :string, required_if: [format: "json"]
+# error: --output is required when --format is 'json'
+
+# Required unless any of the named options is present
+option :config, type: :string, required_unless: [:inline, :stdin]
+
+# Cannot be combined with another option (atom or list)
+option :json, type: :boolean, conflicts_with: :yaml
+option :json, type: :boolean, conflicts_with: [:yaml, :toml]
+
+# Implies that another option must also be present
+option :user, type: :string, requires: :password
+option :deploy, type: :boolean, requires: [:env, :region]
 ```
 
 ## Environment Variable Fallback
@@ -83,6 +106,44 @@ group :auth, co_occurring: true do
   option :password, type: :string
 end
 ```
+
+## Help Customization
+
+```elixir
+# Group options under custom headings
+option :host, type: :string, help_heading: "Network"
+option :port, type: :integer, help_heading: "Network"
+option :user, type: :string, help_heading: "Auth"
+
+# Control display order within a section (lower numbers first)
+option :verbose, type: :boolean, display_order: 1
+option :quiet, type: :boolean, display_order: 2
+
+# Order subcommands in the parent's help
+command "deploy" do
+  display_order 1
+end
+```
+
+Help output groups by heading (default `OPTIONS:` first, then each custom
+heading in declaration order). Within each section items are sorted by
+`:display_order`, with stable fallback to declaration order.
+
+## Subcommand Prefix Inference
+
+```elixir
+command "git" do
+  infer_subcommands true
+
+  subcommand MyApp.CLI.Checkout
+  subcommand MyApp.CLI.Status
+end
+
+# git sta      -> resolves to status
+# git che      -> error: 'che' is ambiguous; candidates: check, checkout
+```
+
+Exact matches always win over prefix inference. Aliases are not prefix-matched.
 
 ## Lifecycle Hooks
 
@@ -152,7 +213,7 @@ The `examples/` directory contains standalone Mix projects you can run and exper
 
 ```elixir
 def deps do
-  [{:cheer, "~> 0.1.0"}]
+  [{:cheer, "~> 0.1"}]
 end
 ```
 

--- a/lib/cheer.ex
+++ b/lib/cheer.ex
@@ -34,7 +34,7 @@ defmodule Cheer do
   - Option parsing via OptionParser
   - Type validation and coercion
   - Help text generation
-  - Shell completion script generation (planned)
+  - Shell completion script generation (bash, zsh, fish)
   """
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -22,9 +22,15 @@ defmodule Cheer.MixProject do
 
   def application do
     [
-      extra_applications: [:logger, :ex_unit]
+      extra_applications: extra_applications(Mix.env())
     ]
   end
+
+  # ExUnit is referenced by Cheer.Test (an in-process test helper) and is needed
+  # at dev/test time so dialyzer can resolve ExUnit.CaptureIO. Production
+  # releases must not bundle or start :ex_unit.
+  defp extra_applications(:prod), do: [:logger]
+  defp extra_applications(_), do: [:logger, :ex_unit]
 
   defp deps do
     [

--- a/test/cheer_test.exs
+++ b/test/cheer_test.exs
@@ -1531,6 +1531,20 @@ defmodule CheerTest do
     def run(args, _raw), do: {:ok, args}
   end
 
+  defmodule TestDisplayOrderHidden do
+    use Cheer.Command
+
+    command "ordered-hidden" do
+      about("display_order combined with hide")
+
+      option(:visible, type: :string, help: "Shown", display_order: 2)
+      option(:secret, type: :string, help: "Hidden", display_order: 1, hide: true)
+    end
+
+    @impl Cheer.Command
+    def run(args, _raw), do: {:ok, args}
+  end
+
   describe "display_order for options" do
     test "options sorted by display_order, unordered fall back to declaration order" do
       output = capture_io(fn -> Cheer.run(TestDisplayOrderOpts, ["--help"]) end)
@@ -1539,6 +1553,12 @@ defmodule CheerTest do
       middle_pos = :binary.match(output, "--middle") |> elem(0)
       assert zulu_pos < alpha_pos
       assert alpha_pos < middle_pos
+    end
+
+    test "hidden options stay hidden even with display_order" do
+      output = capture_io(fn -> Cheer.run(TestDisplayOrderHidden, ["--help"]) end)
+      refute output =~ "--secret"
+      assert output =~ "--visible"
     end
   end
 
@@ -1599,6 +1619,14 @@ defmodule CheerTest do
       a_pos = :binary.match(output, "--a_opt") |> elem(0)
       b_pos = :binary.match(output, "--b_opt") |> elem(0)
       assert a_pos < b_pos
+    end
+
+    test "no default OPTIONS section when every option has a heading" do
+      output = capture_io(fn -> Cheer.run(TestHeadingWithOrder, ["--help"]) end)
+      assert output =~ "NET:"
+      # The default OPTIONS: section header should not appear when every
+      # visible option lives under a custom heading.
+      refute output =~ ~r/^OPTIONS:/m
     end
   end
 
@@ -1703,6 +1731,12 @@ defmodule CheerTest do
       output = capture_io(fn -> Cheer.run(TestInferRoot, ["help", "che"]) end)
       assert output =~ "is ambiguous"
     end
+
+    test "empty argv on an inferring branch shows help (no crash)" do
+      output = capture_io(fn -> Cheer.run(TestInferRoot, []) end)
+      assert output =~ "Tiny git"
+      assert output =~ "COMMANDS:"
+    end
   end
 
   # -- conflicts_with / requires ----------------------------------------------
@@ -1773,6 +1807,14 @@ defmodule CheerTest do
 
     test "errors when both conflicting options are set" do
       output = capture_io(fn -> Cheer.run(TestConflicts, ["--json", "--yaml"]) end)
+      assert output =~ "error: --json cannot be used with --yaml"
+    end
+
+    test "fires regardless of CLI argument order (declaration order wins)" do
+      # :yaml does not declare conflicts_with, but :json does. Validation
+      # iterates options in declaration order, so the error message is always
+      # phrased in terms of the option that owns the constraint.
+      output = capture_io(fn -> Cheer.run(TestConflicts, ["--yaml", "--json"]) end)
       assert output =~ "error: --json cannot be used with --yaml"
     end
 
@@ -1847,6 +1889,21 @@ defmodule CheerTest do
     def run(args, _raw), do: {:ok, args}
   end
 
+  defmodule TestRequiredIfNonString do
+    use Cheer.Command
+
+    command "req-if-typed" do
+      about("Test required_if with non-string trigger values")
+
+      option(:retries, type: :integer)
+      option(:dry_run, type: :boolean)
+      option(:notify, type: :string, required_if: [retries: 0, dry_run: true])
+    end
+
+    @impl Cheer.Command
+    def run(args, _raw), do: {:ok, args}
+  end
+
   defmodule TestRequiredUnless do
     use Cheer.Command
 
@@ -1903,6 +1960,20 @@ defmodule CheerTest do
     test "fires when only the second condition matches" do
       output = capture_io(fn -> Cheer.run(TestRequiredIfMulti, ["--env", "live"]) end)
       assert output =~ "error: --secret is required when --env is 'live'"
+    end
+
+    test "matches integer trigger values" do
+      output = capture_io(fn -> Cheer.run(TestRequiredIfNonString, ["--retries", "0"]) end)
+      assert output =~ "error: --notify is required when --retries is 0"
+    end
+
+    test "matches boolean trigger values" do
+      output = capture_io(fn -> Cheer.run(TestRequiredIfNonString, ["--dry-run"]) end)
+      assert output =~ "error: --notify is required when --dry_run is true"
+    end
+
+    test "no match when integer value differs" do
+      assert {:ok, _} = Cheer.run(TestRequiredIfNonString, ["--retries", "3"])
     end
   end
 


### PR DESCRIPTION
## Summary
Audit and gap-fill before cutting 0.1.4. No new features -- just docs, packaging, and edge-case test coverage for everything that landed since 0.1.3.

## Changes

**README**
- Document all six new option keys and DSL macros added in 0.1.4: \`display_order\`, \`help_heading\`, \`infer_subcommands\`, \`conflicts_with\`, \`requires\`, \`required_if\`, \`required_unless\`
- New sections: Conditional Required + Per-Option Constraints, Help Customization, Subcommand Prefix Inference
- Bump install snippet from \`~> 0.1.0\` to \`~> 0.1\`

**mix.exs**
- \`:ex_unit\` was unconditionally in \`extra_applications\`, which would bundle and start ExUnit in production releases of any consumer. Made conditional on \`Mix.env()\` so prod gets only \`:logger\`, while dev/test still load \`:ex_unit\` for dialyzer to resolve \`Cheer.Test\`'s reference to \`ExUnit.CaptureIO\`. Verified the prod \`.app\` file no longer lists \`ex_unit\`.

**lib/cheer.ex**
- Drop the \`(planned)\` note next to shell completion in the moduledoc -- it shipped in 0.1.1.

**test/cheer_test.exs (7 new edge cases)**
- \`display_order\` on a hidden option still hides it
- \`help_heading\` covering every option produces no default \`OPTIONS:\` section header
- Empty argv on an inferring branch shows help (no crash in prefix-matching)
- \`conflicts_with\` fires regardless of CLI argument order (declaration order owns the message)
- \`required_if\` matches integer trigger values
- \`required_if\` matches boolean trigger values
- \`required_if\` correctly does not match when integer value differs

## Test plan
- [x] \`mix format --check-formatted\`
- [x] \`mix compile --warnings-as-errors\` (dev and prod)
- [x] \`mix credo --strict\`
- [x] \`mix test\` (178 tests, 0 failures -- 7 new)
- [x] \`mix dialyzer\`
- [x] \`mix docs\` (clean, no warnings)
- [x] Verified prod \`.app\` file excludes \`:ex_unit\`

## Follow-up
release-please PR #33 (\`chore(main): release 0.1.4\`) will pick up the four feature PRs once this lands. No CHANGELOG edits in this PR -- release-please owns that file.