### PR TITLE
fix: kebab-case option flags in help + warn on empty version

### DIFF
--- a/lib/cheer/command/compiler.ex
+++ b/lib/cheer/command/compiler.ex
@@ -38,6 +38,20 @@ defmodule Cheer.Command.Compiler do
       end
     end
 
+    # Validate: version/1 called with an empty string is almost always a
+    # mistake -- a common footgun is `version(Application.spec(:my_app,
+    # :vsn) |> to_string())`, which evaluates at compile time before the
+    # .app file exists and collapses to `""`. Use `Mix.Project.config()
+    # [:version]` instead, which is always available while compiling.
+    if version == "" do
+      IO.warn(
+        "#{inspect(env.module)} called `version(\"\")`. Empty version string " <>
+          "is almost always unintended. If you meant to read the version " <>
+          "from mix.exs, try `Mix.Project.config()[:version]`.",
+        Macro.Env.stacktrace(env)
+      )
+    end
+
     # Build groups map: %{group_name => %{opts: [...], members: [...]}}
     groups = build_groups(raw_groups)
 

--- a/lib/cheer/help.ex
+++ b/lib/cheer/help.ex
@@ -141,7 +141,10 @@ defmodule Cheer.Help do
             true -> ""
           end
 
-        IO.puts("  [#{group_name}] (#{constraint}): #{Enum.map_join(members, ", ", &"--#{&1}")}")
+        IO.puts(
+          "  [#{group_name}] (#{constraint}): " <>
+            Enum.map_join(members, ", ", &"--#{flag_from(&1)}")
+        )
       end
 
       IO.puts("")
@@ -221,12 +224,16 @@ defmodule Cheer.Help do
     help = pick_help(opt_opts, long)
     type = Keyword.get(opt_opts, :type, :string)
 
-    base_flag = if type == :boolean, do: "[no-]#{name}", else: to_string(name)
+    base_flag =
+      if type == :boolean,
+        do: "[no-]#{flag_from(name)}",
+        else: flag_from(name)
+
     opt_aliases = Keyword.get(opt_opts, :aliases, [])
 
     flag_name =
       if opt_aliases != [] do
-        alias_str = Enum.map_join(opt_aliases, ", ", &"--#{&1}")
+        alias_str = Enum.map_join(opt_aliases, ", ", &"--#{flag_from(&1)}")
         "#{base_flag} (#{alias_str})"
       else
         base_flag
@@ -266,6 +273,13 @@ defmodule Cheer.Help do
 
     "  #{short}--#{String.pad_trailing(flag_name <> value_suffix, 16)} #{help}#{suffix}"
   end
+
+  # Render an option name as the long flag the parser accepts.
+  # `OptionParser` converts atoms to kebab-case (`:base_port` -> `--base-port`);
+  # help output has to match, otherwise users type what `--help` shows and
+  # get "unknown option".
+  defp flag_from(name) when is_atom(name), do: name |> Atom.to_string() |> flag_from()
+  defp flag_from(name) when is_binary(name), do: String.replace(name, "_", "-")
 
   defp format_usage(meta, prog) do
     parts = ["Usage: #{prog}"]

--- a/test/cheer_test.exs
+++ b/test/cheer_test.exs
@@ -271,6 +271,41 @@ defmodule CheerTest do
     end
   end
 
+  describe "option flag rendering" do
+    defmodule TestUnderscoreOption do
+      use Cheer.Command
+
+      command "under" do
+        about("Underscore option names")
+        option(:base_port, type: :integer, help: "Starting port")
+        option(:replicas_per_master, type: :integer, help: "Replicas")
+      end
+
+      @impl Cheer.Command
+      def run(args, _raw), do: {:ok, args}
+    end
+
+    test "help renders atom option names as kebab-case, matching the parser" do
+      output = capture_io(fn -> Cheer.run(TestUnderscoreOption, ["--help"]) end)
+      # The parser accepts --base-port (OptionParser kebab-case convention);
+      # help has to show the same form so users type what they read.
+      assert output =~ "--base-port"
+      assert output =~ "--replicas-per-master"
+      refute output =~ "--base_port"
+      refute output =~ "--replicas_per_master"
+    end
+
+    test "the rendered flag is accepted by the parser" do
+      output =
+        capture_io(fn ->
+          Cheer.run(TestUnderscoreOption, ["--base-port", "17500"])
+        end)
+
+      # No "unknown option(s)" error means the flag parsed.
+      refute output =~ "unknown option"
+    end
+  end
+
   # -- 5. Unknown subcommand error messages -----------------------------------
 
   describe "unknown subcommand error" do
@@ -1616,8 +1651,8 @@ defmodule CheerTest do
 
     test "display_order applies within a heading section" do
       output = capture_io(fn -> Cheer.run(TestHeadingWithOrder, ["--help"]) end)
-      a_pos = :binary.match(output, "--a_opt") |> elem(0)
-      b_pos = :binary.match(output, "--b_opt") |> elem(0)
+      a_pos = :binary.match(output, "--a-opt") |> elem(0)
+      b_pos = :binary.match(output, "--b-opt") |> elem(0)
       assert a_pos < b_pos
     end
 


### PR DESCRIPTION
Closes #38 and #39. Both bugs caught by a downstream workflow-test harness in the redis-up Elixir project (redis-field-engineering/redis_up_ex).

## #39: Help renders underscores, parser expects hyphens

### Repro

```elixir
command "start" do
  option(:base_port, type: :integer, help: "Starting port")
end
```

`--help` prints `--base_port` but running `--base_port 17500` fails with `error: unknown option(s): --base_port`. The parser (OptionParser underneath) converts atom names to kebab-case -- so `:base_port` only parses as `--base-port`. Help has to match the parser.

### Fix

New `Cheer.Help.flag_from/1` helper that mirrors OptionParser's convention:

```elixir
defp flag_from(name) when is_atom(name), do: name |> Atom.to_string() |> flag_from()
defp flag_from(name) when is_binary(name), do: String.replace(name, "_", "-")
```

Used in `format_option/2` for the primary flag, for alias rendering, and in the group-constraint output at the bottom of help.

### Regression test

```elixir
test "help renders atom option names as kebab-case, matching the parser" do
  output = capture_io(fn -> Cheer.run(TestUnderscoreOption, ["--help"]) end)
  assert output =~ "--base-port"
  assert output =~ "--replicas-per-master"
  refute output =~ "--base_port"
  refute output =~ "--replicas_per_master"
end
```

## #38: Empty version string silently shipped

### Repro

```elixir
command "my-app" do
  version(Application.spec(:my_app, :vsn) |> to_string())
end
```

`Application.spec/2` evaluates at macro expansion, before the `.app` file exists, so it returns `nil`. `to_string(nil)` is `""`. Cheer stored `""` and later printed `my-app ` (trailing space, no version). Silent footgun.

### Fix

At `__before_compile__`, if `@cheer_version` is exactly `""`, emit an `IO.warn/2` pointing at the fix:

```
warning: MyApp called `version("")`. Empty version string is almost always
unintended. If you meant to read the version from mix.exs, try
`Mix.Project.config()[:version]`.
```

Nil (user didn't call `version/1` at all) stays silent -- that's a legitimate "no version declared" state.

### Manual verification

```
$ mix run /tmp/empty_version_test.exs
warning: EmptyVersionTest called `version("")`. Empty version string is
almost always unintended. If you meant to read the version from mix.exs,
try `Mix.Project.config()[:version]`.
  /tmp/empty_version_test.exs:1: EmptyVersionTest (module)
```

## Tests

```
$ mix test
180 tests, 0 failures
```

One pre-existing test (`display_order applies within a heading section`) asserted on `--a_opt` / `--b_opt`; updated to match the now-correct kebab-case output.