### PR TITLE
fix: subcommand usage line drops name + bogus [-- <args>...] (#37)

### DIFF
--- a/lib/cheer/help.ex
+++ b/lib/cheer/help.ex
@@ -309,21 +309,17 @@ defmodule Cheer.Help do
     parts = if meta.options != [], do: parts ++ ["[OPTIONS]"], else: parts
 
     parts =
-      if meta.subcommands == [] do
-        case meta[:trailing_var_arg] do
-          {tva_name, tva_opts} ->
-            label =
-              if Keyword.get(tva_opts, :required, false),
-                do: "<#{tva_name}>...",
-                else: "[#{tva_name}]..."
+      case meta[:trailing_var_arg] do
+        {tva_name, tva_opts} when meta.subcommands == [] ->
+          label =
+            if Keyword.get(tva_opts, :required, false),
+              do: "<#{tva_name}>...",
+              else: "[#{tva_name}]..."
 
-            parts ++ [label]
+          parts ++ [label]
 
-          _ ->
-            parts ++ ["[-- <args>...]"]
-        end
-      else
-        parts
+        _ ->
+          parts
       end
 
     Enum.join(parts, " ")

--- a/lib/cheer/router.ex
+++ b/lib/cheer/router.ex
@@ -28,6 +28,14 @@ defmodule Cheer.Router do
   defp dispatch_with_hooks(command, argv, opts, parent_hooks) do
     meta = command.__cheer_meta__()
 
+    # Resolve prog so help/usage output reflects the full subcommand path.
+    # First entry: default to the root command's name if caller didn't set one.
+    opts =
+      case Keyword.get(opts, :prog) do
+        nil -> Keyword.put(opts, :prog, meta.name)
+        _ -> opts
+      end
+
     # Propagate version from parent if enabled
     meta =
       if meta.version == nil and Keyword.has_key?(opts, :propagated_version) do
@@ -102,7 +110,9 @@ defmodule Cheer.Router do
 
     case match_subcommand(meta.subcommands, [token], infer?) do
       {:ok, sub_module, _} ->
-        resolve_help(sub_module, rest, opts)
+        sub_name = sub_module.__cheer_meta__().name
+        child_opts = Keyword.update(opts, :prog, sub_name, &"#{&1} #{sub_name}")
+        resolve_help(sub_module, rest, child_opts)
 
       {:ambiguous, t, candidates} ->
         print_ambiguous_subcommand(t, candidates)
@@ -119,7 +129,9 @@ defmodule Cheer.Router do
 
     case match_subcommand(meta.subcommands, argv, infer?) do
       {:ok, sub_module, rest} ->
-        dispatch_with_hooks(sub_module, rest, opts, hooks)
+        sub_name = sub_module.__cheer_meta__().name
+        child_opts = Keyword.update!(opts, :prog, &"#{&1} #{sub_name}")
+        dispatch_with_hooks(sub_module, rest, child_opts, hooks)
 
       {:ambiguous, token, candidates} ->
         print_ambiguous_subcommand(token, candidates)

--- a/test/cheer_test.exs
+++ b/test/cheer_test.exs
@@ -984,9 +984,10 @@ defmodule CheerTest do
       assert args[:rest] == []
     end
 
-    test "help usage line shows [-- <args>...]" do
+    test "help usage line omits [-- <args>...] when no trailing_var_arg declared (#37)" do
       output = capture_io(fn -> Cheer.run(TestGreet, ["--help"]) end)
-      assert output =~ "[-- <args>...]"
+      refute output =~ "[-- <args>...]"
+      refute output =~ "-- <args>"
     end
   end
 
@@ -2034,6 +2035,62 @@ defmodule CheerTest do
     test "list form errors when none of the dependencies are present" do
       output = capture_io(fn -> Cheer.run(TestRequiredUnlessList, []) end)
       assert output =~ "error: --input is required unless --stdin, --url is provided"
+    end
+  end
+
+  # -- Subcommand usage line (#37) ---------------------------------------------
+
+  defmodule TestSubUsageLeaf do
+    use Cheer.Command
+
+    command "info" do
+      about("Show detailed info for one instance")
+      argument(:name, type: :string, required: true, help: "Instance name")
+    end
+
+    @impl Cheer.Command
+    def run(args, _raw), do: {:ok, args}
+  end
+
+  defmodule TestSubUsageRoot do
+    use Cheer.Command
+
+    command "demo" do
+      about("Demo root")
+      subcommand(TestSubUsageLeaf)
+    end
+
+    @impl Cheer.Command
+    def run(args, _raw), do: {:ok, args}
+  end
+
+  describe "subcommand usage line (#37)" do
+    test "missing-arg error shows full subcommand path in usage" do
+      output = capture_io(fn -> Cheer.run(TestSubUsageRoot, ["info"]) end)
+      assert output =~ "error: missing required argument(s): <name>"
+      assert output =~ "Usage: demo info <name>"
+    end
+
+    test "subcommand --help shows full subcommand path in usage" do
+      output = capture_io(fn -> Cheer.run(TestSubUsageRoot, ["info", "--help"]) end)
+      assert output =~ "Usage: demo info <name>"
+    end
+
+    test "help <sub> also shows full subcommand path" do
+      output = capture_io(fn -> Cheer.run(TestSubUsageRoot, ["help", "info"]) end)
+      assert output =~ "Usage: demo info <name>"
+    end
+
+    test "caller-supplied :prog is extended, not replaced" do
+      output =
+        capture_io(fn -> Cheer.run(TestSubUsageRoot, ["info", "--help"], prog: "my-app") end)
+
+      assert output =~ "Usage: my-app info <name>"
+    end
+
+    test "subcommand usage does not append bogus [-- <args>...]" do
+      output = capture_io(fn -> Cheer.run(TestSubUsageRoot, ["info", "--help"]) end)
+      refute output =~ "[-- <args>...]"
     end
   end
 end


### PR DESCRIPTION
Closes #37.

Two related subcommand-usage-rendering bugs surfaced by the same downstream consumer (`redis_up_ex`) that reported #38/#39. Small, contained fix; appropriate to bundle into 0.1.5.

## #37.1: Missing subcommand name in usage line

### Repro

```elixir
defmodule Demo.Info do
  use Cheer.Command

  command "info" do
    about("Show detailed info for one instance")
    argument(:name, type: :string, required: true, help: "Instance name")
  end

  def run(%{name: name}, _raw), do: IO.puts("info for #{name}")
end

defmodule Demo do
  use Cheer.Command

  command "demo" do
    subcommand(Demo.Info)
  end
end

Cheer.run(Demo, ["info"], prog: "redis-up")
```

Before:

```
error: missing required argument(s): <name>

Usage: redis-up <name> [-- <args>...]
```

After:

```
error: missing required argument(s): <name>

Usage: redis-up info <name>
```

### Root cause

`Router.dispatch_with_hooks` never extended `opts[:prog]` when descending into a subcommand. When the `info` leaf printed help (e.g. on missing-arg error), `Help.print/2` received the root's `prog` and used it alongside `meta.name = "info"` for arguments -- but never prepended `"info"` itself.

### Fix

Resolve `:prog` on first entry into `dispatch_with_hooks` (default to root command's name when caller did not supply one), then extend it with the subcommand name each time we descend. Covers both normal dispatch and `help <sub>` resolution.

## #37.2: Bogus `[-- <args>...]` suffix

Every leaf command without `trailing_var_arg` had `[-- <args>...]` appended to its usage line, implying a trailing-args interface the command never declared. Cheer still captures post-separator tokens in `:rest` internally (unchanged), but that is an implementation detail and does not belong in user-facing help.

Fix: only render the trailing-args label when `trailing_var_arg` is actually declared.

## Tests

```
$ mix test
185 tests, 0 failures
```

Added `describe "subcommand usage line (#37)"` block with 5 regression tests covering: missing-arg error path, `--help`, `help <sub>`, caller-supplied `:prog` extension, and no-bogus-suffix. Flipped one pre-existing test (`test/cheer_test.exs:987`) that had asserted the buggy `[-- <args>...]` output.

Full pre-commit checklist passes: `mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix credo --strict`.