### PR TITLE
feat: external_subcommands (plugin-style dispatchers) (#25)

### DIFF
--- a/lib/cheer/command.ex
+++ b/lib/cheer/command.ex
@@ -47,6 +47,7 @@ defmodule Cheer.Command do
       Module.register_attribute(__MODULE__, :cheer_subcommand_required, accumulate: false)
       Module.register_attribute(__MODULE__, :cheer_propagate_version, accumulate: false)
       Module.register_attribute(__MODULE__, :cheer_infer_subcommands, accumulate: false)
+      Module.register_attribute(__MODULE__, :cheer_external_subcommands, accumulate: false)
       Module.register_attribute(__MODULE__, :cheer_display_order, accumulate: false)
       Module.register_attribute(__MODULE__, :cheer_trailing_var_arg, accumulate: false)
       Module.register_attribute(__MODULE__, :cheer_arguments, accumulate: true)

--- a/lib/cheer/command/compiler.ex
+++ b/lib/cheer/command/compiler.ex
@@ -16,6 +16,10 @@ defmodule Cheer.Command.Compiler do
     subcommand_required = Module.get_attribute(env.module, :cheer_subcommand_required) || false
     propagate_version = Module.get_attribute(env.module, :cheer_propagate_version) || false
     infer_subcommands = Module.get_attribute(env.module, :cheer_infer_subcommands) || false
+
+    external_subcommands =
+      Module.get_attribute(env.module, :cheer_external_subcommands) || false
+
     display_order = Module.get_attribute(env.module, :cheer_display_order)
     trailing_var_arg = Module.get_attribute(env.module, :cheer_trailing_var_arg)
     arguments = Module.get_attribute(env.module, :cheer_arguments) |> Enum.reverse()
@@ -109,6 +113,7 @@ defmodule Cheer.Command.Compiler do
           subcommand_required: unquote(subcommand_required),
           propagate_version: unquote(propagate_version),
           infer_subcommands: unquote(infer_subcommands),
+          external_subcommands: unquote(external_subcommands),
           display_order: unquote(display_order),
           trailing_var_arg: unquote(Macro.escape(trailing_var_arg)),
           arguments: unquote(arguments_expr),

--- a/lib/cheer/command/dsl.ex
+++ b/lib/cheer/command/dsl.ex
@@ -59,6 +59,34 @@ defmodule Cheer.Command.DSL do
   defmacro infer_subcommands(val), do: quote(do: @cheer_infer_subcommands(unquote(val)))
 
   @doc """
+  Allow this command to accept unknown subcommands (e.g. plugins on `$PATH`).
+
+  When enabled, any argv token that does not match a declared subcommand and is
+  not an option is captured and surfaced to `run/2` via
+  `args[:external_subcommand]` as `{name, rest_argv}`. Declared subcommands
+  still take precedence. Commands that opt in should generally not also declare
+  positional arguments -- leftover positionals are routed to the external-sub
+  capture, not to arguments.
+
+  Example: a `git`-style plugin dispatcher that execs `git-<name>` from `$PATH`.
+
+      command "git-like" do
+        external_subcommands(true)
+
+        # ... declared subs, options ...
+      end
+
+      def run(args, _raw) do
+        case args[:external_subcommand] do
+          {name, rest} -> System.cmd("git-\#{name}", rest)
+          nil -> :ok
+        end
+      end
+  """
+  defmacro external_subcommands(val),
+    do: quote(do: @cheer_external_subcommands(unquote(val)))
+
+  @doc """
   Set this command's display order as a subcommand in its parent's help output.
 
   Lower numbers appear first. Commands without an explicit order fall back to

--- a/lib/cheer/router.ex
+++ b/lib/cheer/router.ex
@@ -126,6 +126,7 @@ defmodule Cheer.Router do
 
   defp dispatch_command(command, meta, argv, opts, hooks) do
     infer? = Map.get(meta, :infer_subcommands, false)
+    external? = Map.get(meta, :external_subcommands, false)
 
     case match_subcommand(meta.subcommands, argv, infer?) do
       {:ok, sub_module, rest} ->
@@ -136,6 +137,9 @@ defmodule Cheer.Router do
       {:ambiguous, token, candidates} ->
         print_ambiguous_subcommand(token, candidates)
 
+      {:error, _unknown_token} when external? ->
+        run_leaf(command, meta, argv, opts, hooks)
+
       {:error, unknown_token} ->
         print_unknown_command(meta, unknown_token)
 
@@ -144,24 +148,31 @@ defmodule Cheer.Router do
         IO.puts("")
         Cheer.Help.print(command, opts)
 
-      :none when meta.subcommands != [] ->
+      :none when meta.subcommands != [] and not external? ->
+        Cheer.Help.print(command, opts)
+
+      :none when meta.subcommands != [] and argv == [] ->
         Cheer.Help.print(command, opts)
 
       :none ->
-        case parse_and_validate(command, meta, argv, opts) do
-          {:ok, args} ->
-            # Apply persistent hooks from parents, then local before_run
-            args = apply_hooks(args, hooks)
-            args = apply_hooks(args, Map.get(meta, :before_run, []))
+        run_leaf(command, meta, argv, opts, hooks)
+    end
+  end
 
-            result = command.run(args, argv)
+  defp run_leaf(command, meta, argv, opts, hooks) do
+    case parse_and_validate(command, meta, argv, opts) do
+      {:ok, args} ->
+        # Apply persistent hooks from parents, then local before_run
+        args = apply_hooks(args, hooks)
+        args = apply_hooks(args, Map.get(meta, :before_run, []))
 
-            # Apply after_run hooks
-            apply_after_hooks(result, Map.get(meta, :after_run, []))
+        result = command.run(args, argv)
 
-          :handled ->
-            :ok
-        end
+        # Apply after_run hooks
+        apply_after_hooks(result, Map.get(meta, :after_run, []))
+
+      :handled ->
+        :ok
     end
   end
 
@@ -182,6 +193,14 @@ defmodule Cheer.Router do
   # -- Parsing pipeline --
 
   defp parse_and_validate(command, meta, argv, opts) do
+    if Map.get(meta, :external_subcommands, false) do
+      parse_with_external_subcommand(command, meta, argv, opts)
+    else
+      parse_standard(command, meta, argv, opts)
+    end
+  end
+
+  defp parse_standard(command, meta, argv, opts) do
     # Merge parent global options with this command's options
     parent_globals = Keyword.get(opts, :parent_globals, [])
 
@@ -236,6 +255,61 @@ defmodule Cheer.Router do
           _ ->
             missing
         end
+
+      cond do
+        missing != [] ->
+          print_missing_args_error(command, missing, opts)
+          :handled
+
+        true ->
+          with :ok <- validate_conditional_required(args, all_options),
+               :ok <- validate_constraints(args, all_options),
+               :ok <- validate_groups(args, Map.get(meta, :groups, %{})),
+               :ok <- validate_params(args, all_options),
+               :ok <- run_validators(args, Map.get(meta, :validators, [])) do
+            {:ok, args}
+          else
+            {:error, msg} ->
+              IO.puts("error: #{msg}")
+              :handled
+          end
+      end
+    end
+  end
+
+  # Parse path for commands with `external_subcommands: true`. Uses parse_head
+  # so the first non-option token (and everything after) is surfaced as the
+  # external subcommand rather than being treated as a parent positional or as
+  # an unknown-option error.
+  defp parse_with_external_subcommand(command, meta, argv, opts) do
+    parent_globals = Keyword.get(opts, :parent_globals, [])
+
+    inherited_globals =
+      Enum.reject(parent_globals, fn {name, _} ->
+        Enum.any?(meta.options, fn {n, _} -> n == name end)
+      end)
+
+    all_options = meta.options ++ inherited_globals
+    {option_parser_opts, option_aliases} = build_option_parser_spec(all_options)
+
+    {parsed, positional, invalid} =
+      OptionParser.parse_head(argv, strict: option_parser_opts, aliases: option_aliases)
+
+    if invalid != [] do
+      print_invalid_options_error(command, invalid, opts)
+      :handled
+    else
+      args = apply_defaults(all_options)
+      args = apply_env_vars(args, all_options)
+      args = Map.merge(args, build_parsed_map(parsed, all_options))
+
+      args =
+        case positional do
+          [] -> Map.put(args, :external_subcommand, nil)
+          [name | rest] -> Map.put(args, :external_subcommand, {name, rest})
+        end
+
+      missing = missing_required_options(all_options, args)
 
       cond do
         missing != [] ->

--- a/test/cheer_test.exs
+++ b/test/cheer_test.exs
@@ -2150,4 +2150,95 @@ defmodule CheerTest do
       refute output =~ "[-- <args>...]"
     end
   end
+
+  # -- external_subcommands (#25) ----------------------------------------------
+
+  defmodule TestExternalSub.Status do
+    use Cheer.Command
+
+    command "status" do
+      about("Show status")
+    end
+
+    @impl Cheer.Command
+    def run(_args, _raw), do: {:ok, :status_ran}
+  end
+
+  defmodule TestExternalSub do
+    use Cheer.Command
+
+    command "git-like" do
+      about("A git-style plugin dispatcher")
+      external_subcommands(true)
+      option(:verbose, type: :boolean, short: :v, help: "Verbose output")
+      subcommand(TestExternalSub.Status)
+    end
+
+    @impl Cheer.Command
+    def run(args, _raw), do: {:ok, args}
+  end
+
+  defmodule TestNoExternalSub do
+    use Cheer.Command
+
+    command "strict" do
+      about("Without external_subcommands")
+      subcommand(TestExternalSub.Status)
+    end
+  end
+
+  describe "external_subcommands (#25)" do
+    test "unknown token is captured under :external_subcommand as {name, rest}" do
+      assert {:ok, args} = Cheer.run(TestExternalSub, ["foo", "bar", "baz"])
+      assert args[:external_subcommand] == {"foo", ["bar", "baz"]}
+    end
+
+    test "unknown token with no trailing args gives empty rest" do
+      assert {:ok, args} = Cheer.run(TestExternalSub, ["foo"])
+      assert args[:external_subcommand] == {"foo", []}
+    end
+
+    test "declared subcommand takes precedence over external capture" do
+      assert {:ok, :status_ran} = Cheer.run(TestExternalSub, ["status"])
+    end
+
+    test "parent options parsed before the external token" do
+      assert {:ok, args} = Cheer.run(TestExternalSub, ["--verbose", "foo", "bar"])
+      assert args[:verbose] == true
+      assert args[:external_subcommand] == {"foo", ["bar"]}
+    end
+
+    test "tokens after the external name are passed through verbatim, including flags" do
+      assert {:ok, args} = Cheer.run(TestExternalSub, ["foo", "--unknown-flag", "value"])
+      assert args[:external_subcommand] == {"foo", ["--unknown-flag", "value"]}
+    end
+
+    test "short-option alias still resolves on the parent" do
+      assert {:ok, args} = Cheer.run(TestExternalSub, ["-v", "foo"])
+      assert args[:verbose] == true
+      assert args[:external_subcommand] == {"foo", []}
+    end
+
+    test "no external invocation sets :external_subcommand to nil" do
+      assert {:ok, args} = Cheer.run(TestExternalSub, ["--verbose"])
+      assert args[:verbose] == true
+      assert args[:external_subcommand] == nil
+    end
+
+    test "empty argv with subcommands declared still shows help" do
+      output = capture_io(fn -> Cheer.run(TestExternalSub, []) end)
+      assert output =~ "COMMANDS:"
+      assert output =~ "status"
+    end
+
+    test "invalid parent option before external name still errors" do
+      output = capture_io(fn -> Cheer.run(TestExternalSub, ["--nope", "foo"]) end)
+      assert output =~ "error: unknown option(s): --nope"
+    end
+
+    test "commands with subcommands and no external_subcommands still error on unknown tokens (regression)" do
+      output = capture_io(fn -> Cheer.run(TestNoExternalSub, ["surprise"]) end)
+      assert output =~ "error: unknown command 'surprise'"
+    end
+  end
 end


### PR DESCRIPTION
Closes #25.

Adds `external_subcommands(true)` to the command DSL -- lets a command accept unknown subcommand tokens and surface them to `run/2` instead of erroring. Enables git-style plugin dispatchers.

## DSL

```elixir
command "git-like" do
  about("git-style plugin dispatcher")
  external_subcommands(true)
  option(:verbose, type: :boolean, short: :v)

  subcommand(MyApp.Status)   # declared subs still take precedence
end

def run(args, _raw) do
  case args[:external_subcommand] do
    {name, rest} -> System.cmd("git-like-#{name}", rest)
    nil          -> :ok
  end
end
```

## Behavior

| Invocation | Result |
|---|---|
| `git-like status` | Dispatches to declared `MyApp.Status.run/2` |
| `git-like deploy --env prod` | `args[:external_subcommand] = {"deploy", ["--env", "prod"]}` |
| `git-like -v deploy api` | `args[:verbose] = true`, `args[:external_subcommand] = {"deploy", ["api"]}` |
| `git-like --verbose` | `args[:verbose] = true`, `args[:external_subcommand] = nil` |
| `git-like` (no args) | Shows help |
| `git-like --nope foo` | `error: unknown option(s): --nope` (parent-level invalid options still caught) |

Key invariants:
- Declared subcommands match first, unchanged.
- Everything after the external name (including flags the parent does not know about) is passed through verbatim.
- `args[:external_subcommand]` is `nil` when no external sub was invoked and `{name, rest}` when one was -- never absent, so pattern matches are total.
- Empty argv with declared subcommands still shows help.

## Implementation

**Parse-head path.** When a command opts in, `parse_and_validate` switches to `OptionParser.parse_head/2`, which stops consuming argv at the first non-option token. That token is the external subcommand name; everything after is preserved verbatim. Parent-level validation (required options, `conflicts_with`/`requires`, groups, choices, custom validators) still runs.

**Positional arguments are skipped in external mode.** Declaring `argument(...)` alongside `external_subcommands(true)` is incoherent -- the same tokens can't simultaneously be parent args and the external sub name. Rather than erroring at compile time, the DSL docstring tells users not to.

**Router.** New `{:error, _unknown_token} when external?` branch in `dispatch_command` falls through to the parse path instead of calling `print_unknown_command`. The `:none` branches are guarded so that empty argv with declared subcommands still shows help, matching existing behavior.

## Tests

10 new tests under `describe "external_subcommands (#25)"`:
- Capture with/without trailing args.
- Declared subcommand precedence.
- Parent options parsed before external token.
- Passthrough of unknown flags after external name.
- Short-option alias resolution on the parent.
- Nil shape when no external invocation.
- Empty-argv help behavior preserved.
- Invalid parent option before external still errors.
- Regression guard: commands with declared subs + no `external_subcommands` still error on unknown tokens.

```
$ mix test
200 tests, 0 failures
```

`mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix credo --strict` all clean.