### PR TITLE
docs: split README into docs/ tree with guides and cookbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,28 +5,11 @@
 [![Hex Docs](https://img.shields.io/badge/hex-docs-blue.svg)](https://hexdocs.pm/cheer)
 [![License](https://img.shields.io/hexpm/l/cheer.svg)](LICENSE)
 
-A clap-inspired CLI framework for Elixir. Define your command tree once and get parsing, validation, help, shell completion, REPL mode, and testing for free.
+A clap-inspired CLI framework for Elixir. Define your command tree once and
+get parsing, validation, help, shell completion, a REPL, and in-process
+testing for free.
 
-## Features
-
-- **Declarative DSL** -- define commands, options, arguments, and subcommands with macros
-- **Arbitrary nesting** -- subcommand trees of any depth
-- **Typed options and arguments** -- `:string`, `:integer`, `:float`, `:boolean` with automatic coercion
-- **Validation** -- per-param (`:validate`, `:choices`), cross-param (`validate/1`), required fields
-- **Conditional required** -- `:required_if` and `:required_unless` for inter-option dependencies
-- **Per-option constraints** -- `:conflicts_with` and `:requires` for relational rules
-- **Environment variable fallback** -- `option :port, env: "MY_PORT"`
-- **Param groups** -- mutually exclusive and co-occurring option groups
-- **Lifecycle hooks** -- `before_run`, `after_run`, `persistent_before_run` (inherited by children)
-- **Auto-generated help** -- defaults, env vars, choices, groups, custom headings, ordering
-- **Subcommand prefix inference** -- `infer_subcommands true` resolves unambiguous prefixes
-- **Shell completion** -- bash, zsh, and fish script generation
-- **REPL mode** -- interactive command shell from the same command tree
-- **In-process test runner** -- `Cheer.Test.run/3` captures output and return values
-- **Command tree introspection** -- `Cheer.tree/1` returns the tree as data
-- **"Did you mean?"** -- typo suggestions via Jaro distance
-
-## Quick Start
+## 30-second taste
 
 ```elixir
 defmodule MyApp.CLI.Greet do
@@ -46,175 +29,67 @@ defmodule MyApp.CLI.Greet do
   end
 end
 
-# Run it
 Cheer.run(MyApp.CLI.Greet, ["world", "--loud"], prog: "greet")
+# "HELLO, WORLD!"
 ```
 
-## Validation
+## Features
 
-```elixir
-# Per-param: inline function
-option :port, type: :integer,
-  validate: fn p -> if p in 1024..65_535, do: :ok, else: {:error, "invalid port"} end
+- Declarative macro DSL for commands, options, arguments, and subcommands
+- Typed options and arguments with automatic coercion
+- Per-param and cross-param validation, choices, conditional-required
+- Per-option relations (`:conflicts_with`, `:requires`) and param groups
+- Env var fallback, defaults, boolean negation (`--no-*`)
+- Auto-generated help with headings, display order, before/after text
+- Subcommand prefix inference and `"Did you mean?"` suggestions
+- External subcommands for git-style plugin dispatchers
+- Shell completion for bash, zsh, fish, and PowerShell
+- REPL mode driven by the same command tree
+- In-process test runner with output capture
+- Command tree introspection (`Cheer.tree/1`) for docs and scripts
+- Zero runtime dependencies
 
-# Per-param: choices
-option :format, type: :string, choices: ["json", "csv", "table"]
-
-# Cross-param: runs after all params are parsed
-validate fn args ->
-  if args[:tls] && !args[:cert], do: {:error, "--tls requires --cert"}, else: :ok
-end
-```
-
-## Conditional Required and Per-Option Constraints
-
-```elixir
-# Required only when another option holds a particular value
-option :format, type: :string, choices: ["json", "table"]
-option :output, type: :string, required_if: [format: "json"]
-# error: --output is required when --format is 'json'
-
-# Required unless any of the named options is present
-option :config, type: :string, required_unless: [:inline, :stdin]
-
-# Cannot be combined with another option (atom or list)
-option :json, type: :boolean, conflicts_with: :yaml
-option :json, type: :boolean, conflicts_with: [:yaml, :toml]
-
-# Implies that another option must also be present
-option :user, type: :string, requires: :password
-option :deploy, type: :boolean, requires: [:env, :region]
-```
-
-## Environment Variable Fallback
-
-```elixir
-option :port, type: :integer, default: 4000, env: "PORT"
-# Priority: CLI flag > env var > default
-```
-
-## Param Groups
-
-```elixir
-group :format, mutually_exclusive: true do
-  option :json, type: :boolean
-  option :csv, type: :boolean
-end
-
-group :auth, co_occurring: true do
-  option :username, type: :string
-  option :password, type: :string
-end
-```
-
-## Help Customization
-
-```elixir
-# Group options under custom headings
-option :host, type: :string, help_heading: "Network"
-option :port, type: :integer, help_heading: "Network"
-option :user, type: :string, help_heading: "Auth"
-
-# Control display order within a section (lower numbers first)
-option :verbose, type: :boolean, display_order: 1
-option :quiet, type: :boolean, display_order: 2
-
-# Order subcommands in the parent's help
-command "deploy" do
-  display_order 1
-end
-```
-
-Help output groups by heading (default `OPTIONS:` first, then each custom
-heading in declaration order). Within each section items are sorted by
-`:display_order`, with stable fallback to declaration order.
-
-## Subcommand Prefix Inference
-
-```elixir
-command "git" do
-  infer_subcommands true
-
-  subcommand MyApp.CLI.Checkout
-  subcommand MyApp.CLI.Status
-end
-
-# git sta      -> resolves to status
-# git che      -> error: 'che' is ambiguous; candidates: check, checkout
-```
-
-Exact matches always win over prefix inference. Aliases are not prefix-matched.
-
-## Lifecycle Hooks
-
-```elixir
-before_run fn args -> Map.put(args, :debug, true) end
-after_run fn result -> log(result); result end
-
-# Inherited by ALL child subcommands
-persistent_before_run fn args -> Map.put(args, :logger, init_logger()) end
-```
-
-## Shell Completion
-
-```elixir
-Cheer.Completion.generate(MyApp.CLI.Root, :bash, prog: "my-app")
-# Also :zsh and :fish
-```
-
-## REPL Mode
-
-```elixir
-Cheer.Repl.start(MyApp.CLI.Root, prog: "my-app")
-# my-app> greet world
-# my-app> exit
-```
-
-## Testing
-
-```elixir
-result = Cheer.Test.run(MyApp.CLI.Greet, ["world"])
-assert result.return == "Hello, world!"
-assert result.output == ""
-```
-
-## Introspection
-
-```elixir
-Cheer.tree(MyApp.CLI.Root)
-# %{name: "my-app", subcommands: [%{name: "greet", ...}, ...]}
-```
-
-## Examples
-
-The `examples/` directory contains standalone Mix projects you can run and experiment with:
-
-- **[greeter](examples/greeter/)** -- Minimal single-command CLI. Demonstrates arguments, typed options, validation, defaults, and environment variable fallback.
-
-  ```sh
-  cd examples/greeter
-  mix deps.get
-  mix run -e 'Greeter.CLI.main(["world", "--loud", "--times", "3"])'
-  # HELLO, WORLD!
-  # HELLO, WORLD!
-  # HELLO, WORLD!
-  ```
-
-- **[devtool](examples/devtool/)** -- Nested multi-command CLI (`devtool server start`, `devtool db migrate`, etc.). Demonstrates subcommand trees, persistent lifecycle hooks, mutually exclusive param groups, and cross-param validation.
-
-  ```sh
-  cd examples/devtool
-  mix deps.get
-  mix run -e 'Devtool.CLI.main(["server", "start", "--port", "8080", "--https"])'
-  # Starting server at https://localhost:8080
-  ```
-
-## Installation
+## Install
 
 ```elixir
 def deps do
   [{:cheer, "~> 0.1"}]
 end
+```
+
+## Documentation
+
+Full docs on [hexdocs.pm/cheer](https://hexdocs.pm/cheer):
+
+- **[Getting started](https://hexdocs.pm/cheer/getting_started.html)** -- install and a five-minute tour.
+- **[Concepts](https://hexdocs.pm/cheer/concepts.html)** -- vocabulary and mental model.
+- **Guides:**
+  [Options](https://hexdocs.pm/cheer/options.html),
+  [Arguments](https://hexdocs.pm/cheer/arguments.html),
+  [Subcommands](https://hexdocs.pm/cheer/subcommands.html),
+  [Validation](https://hexdocs.pm/cheer/validation.html),
+  [Constraints](https://hexdocs.pm/cheer/constraints.html),
+  [Help and output](https://hexdocs.pm/cheer/help_and_output.html),
+  [Lifecycle hooks](https://hexdocs.pm/cheer/lifecycle_hooks.html),
+  [Shell completion](https://hexdocs.pm/cheer/shell_completion.html),
+  [REPL](https://hexdocs.pm/cheer/repl.html),
+  [Testing](https://hexdocs.pm/cheer/testing.html).
+- **Cookbook:**
+  [Greeter](https://hexdocs.pm/cheer/greeter.html) (single command),
+  [Devtool](https://hexdocs.pm/cheer/devtool.html) (nested subcommands with hooks and groups).
+
+## Runnable examples
+
+Standalone Mix projects that match the cookbook entries live under
+[`examples/`](examples/):
+
+- [`examples/greeter/`](examples/greeter/) -- minimal single-command CLI.
+- [`examples/devtool/`](examples/devtool/) -- nested multi-command CLI
+  with lifecycle hooks and groups.
+
+```sh
+cd examples/greeter && mix deps.get
+mix run -e 'Greeter.CLI.main(["world", "--loud", "--times", "3"])'
 ```
 
 ## License

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,0 +1,94 @@
+# Concepts
+
+A short vocabulary tour. Read once, then skim the guides.
+
+## Command
+
+A module that `use Cheer.Command` and declares a `command "<name>" do ... end`
+block. Commands compose into trees of arbitrary depth.
+
+```elixir
+defmodule MyApp.CLI.Deploy do
+  use Cheer.Command
+
+  command "deploy" do
+    about "Deploy to an environment"
+    # ... options, arguments, subcommands ...
+  end
+
+  @impl Cheer.Command
+  def run(args, _raw), do: ...
+end
+```
+
+Leaf commands (no subcommands) must implement `run/2`. Branch commands route
+argv to their children automatically.
+
+## Argument
+
+A positional input. Matched by position, typed, optionally required.
+
+```elixir
+argument :name, type: :string, required: true, help: "Who to greet"
+```
+
+## Option
+
+A flag. Long form (`--port`), optional short alias (`-p`), optional value,
+optional type. Boolean options automatically support `--no-<name>` negation.
+
+```elixir
+option :port, type: :integer, short: :p, default: 4000, env: "PORT"
+option :verbose, type: :boolean, short: :v
+```
+
+Cheer normalizes atom names to kebab-case in both the parser and help output,
+so `:base_port` becomes `--base-port`.
+
+## Subcommand
+
+A nested command module registered under its parent:
+
+```elixir
+command "devtool" do
+  subcommand Devtool.Server   # devtool server ...
+  subcommand Devtool.Db       # devtool db ...
+end
+```
+
+Subcommand trees can nest arbitrarily deep.
+
+## Run
+
+A leaf command's handler. Receives a parsed `args` map and the raw `argv`:
+
+```elixir
+@impl Cheer.Command
+def run(args, _raw_argv) do
+  # args is already parsed, typed, validated
+end
+```
+
+The `args` map contains parsed arguments and options by their declared name,
+plus any defaults and environment-variable fallbacks that applied. Unknown
+trailing tokens (after `--`) land in `args[:rest]` unless the command
+declares a named `trailing_var_arg`.
+
+## Help, usage, version
+
+Every command gets `-h` / `--help` automatically. Commands that call
+`version("1.0.0")` also get `-V` / `--version`. Help output is derived from
+the metadata you declared, not from a parallel format file.
+
+## Metadata
+
+Every command has a compile-time `__cheer_meta__/0` function that returns the
+full declaration as a data structure. `Cheer.tree/1` walks the tree and
+returns a nested map, useful for documentation, completion scripts, and
+testing.
+
+## Test runner
+
+`Cheer.Test.run/3` invokes a command in-process, captures stdout, and returns
+both the output and the handler's return value. No subprocess, no argv
+escaping. See [Testing](guides/testing.md).

--- a/docs/cookbook/devtool.md
+++ b/docs/cookbook/devtool.md
@@ -1,0 +1,211 @@
+# Devtool: nested subcommands with hooks and groups
+
+A multi-command developer toolkit. `devtool server start`, `devtool db
+migrate`, etc. Exercises subcommand nesting, a persistent lifecycle hook,
+per-command hooks, mutually exclusive option groups, choices, and cross-param
+validation.
+
+Full runnable project: [`examples/devtool/`](https://github.com/joshrotenberg/cheer/tree/main/examples/devtool).
+
+## Layout
+
+```
+devtool
+  server
+    start   -- starts the dev server
+    stop    -- stops it
+  db
+    migrate -- runs migrations
+    seed    -- seeds the database
+```
+
+## The root
+
+```elixir
+defmodule Devtool.CLI do
+  use Cheer.Command
+
+  command "devtool" do
+    about "Developer toolkit"
+    version "0.1.0"
+
+    persistent_before_run fn args ->
+      Map.put(args, :start_time, System.monotonic_time(:millisecond))
+    end
+
+    subcommand Devtool.Server
+    subcommand Devtool.Db
+  end
+
+  def main(argv) do
+    Cheer.run(__MODULE__, argv, prog: "devtool")
+  end
+end
+```
+
+`persistent_before_run` declared on the root propagates to every descendant.
+Every leaf-command handler sees `args[:start_time]` regardless of which
+subcommand was invoked.
+
+## A branch: `server`
+
+```elixir
+defmodule Devtool.Server do
+  use Cheer.Command
+
+  command "server" do
+    about "Server management"
+
+    subcommand Devtool.Server.Start
+    subcommand Devtool.Server.Stop
+  end
+end
+```
+
+Branches have no `run/2` -- cheer routes to children automatically.
+
+## A leaf with a group and a validator: `server start`
+
+```elixir
+defmodule Devtool.Server.Start do
+  use Cheer.Command
+
+  command "start" do
+    about "Start the dev server"
+
+    option :port, type: :integer, short: :p, default: 4000, env: "DEV_PORT",
+      validate: fn p -> if p in 1024..65535, do: :ok, else: {:error, "port must be 1024-65535"} end,
+      help: "Port to listen on"
+
+    option :host, type: :string, short: :H, default: "localhost", help: "Bind address"
+
+    group :protocol, mutually_exclusive: true do
+      option :http,  type: :boolean, help: "Use HTTP"
+      option :https, type: :boolean, help: "Use HTTPS"
+    end
+  end
+
+  @impl Cheer.Command
+  def run(args, _raw) do
+    protocol = if args[:https], do: "https", else: "http"
+    IO.puts("Starting server at #{protocol}://#{args[:host]}:#{args[:port]}")
+    IO.puts("(started in #{elapsed(args)}ms)")
+  end
+
+  defp elapsed(%{start_time: t}), do: System.monotonic_time(:millisecond) - t
+  defp elapsed(_), do: 0
+end
+```
+
+Passing both `--http --https` produces a friendly error from the group
+constraint.
+
+## A leaf with before/after hooks: `db migrate`
+
+```elixir
+defmodule Devtool.Db.Migrate do
+  use Cheer.Command
+
+  command "migrate" do
+    about "Run database migrations"
+
+    option :target,  type: :string, short: :t, help: "Target migration version"
+    option :dry_run, type: :boolean, help: "Show what would be run without applying"
+
+    before_run fn args ->
+      IO.puts("Connecting to database...")
+      args
+    end
+
+    after_run fn result ->
+      IO.puts("Done.")
+      result
+    end
+  end
+
+  @impl Cheer.Command
+  def run(args, _raw) do
+    prefix = if args[:dry_run], do: "[dry run] ", else: ""
+
+    case args[:target] do
+      nil    -> IO.puts("#{prefix}Running all pending migrations...")
+      target -> IO.puts("#{prefix}Migrating to version #{target}...")
+    end
+  end
+end
+```
+
+Hooks run in order: root `persistent_before_run`, then this command's
+`before_run`, then `run/2`, then `after_run`.
+
+## A leaf with choices and cross-param validation: `db seed`
+
+```elixir
+defmodule Devtool.Db.Seed do
+  use Cheer.Command
+
+  command "seed" do
+    about "Seed the database"
+
+    option :env, type: :string, default: "development",
+      choices: ["development", "staging", "test"],
+      help: "Target environment"
+
+    option :clean, type: :boolean, help: "Truncate tables before seeding"
+
+    validate fn args ->
+      if args[:clean] && args[:env] == "staging" do
+        {:error, "cannot use --clean with staging environment"}
+      else
+        :ok
+      end
+    end
+  end
+
+  @impl Cheer.Command
+  def run(args, _raw) do
+    if args[:clean], do: IO.puts("Truncating tables...")
+    IO.puts("Seeding #{args[:env]} database...")
+  end
+end
+```
+
+Type coercion, choices validation, and the cross-param `validate` all run
+before `run/2`.
+
+## Run it
+
+```sh
+cd examples/devtool
+mix deps.get
+
+mix run -e 'Devtool.CLI.main(["server", "start", "--port", "8080", "--https"])'
+# Starting server at https://localhost:8080
+# (started in 0ms)
+
+mix run -e 'Devtool.CLI.main(["db", "migrate", "--target", "20240101"])'
+# Connecting to database...
+# Migrating to version 20240101...
+# Done.
+
+mix run -e 'Devtool.CLI.main(["db", "seed", "--env", "staging", "--clean"])'
+# error: cannot use --clean with staging environment
+
+mix run -e 'Devtool.CLI.main(["server", "--help"])'
+```
+
+## What it shows
+
+- **Nested command tree** with branches that have no `run/2`.
+- **Persistent lifecycle hook** propagated from the root to every leaf.
+- **Per-command `before_run` / `after_run`** hooks.
+- **Mutually exclusive option group** with auto-generated error message.
+- **Choices** for string-enum options.
+- **Cross-param validator** enforcing a rule across two options.
+- **Env var fallback** combined with a validator.
+
+## See also
+
+- Guides: [Subcommands](../guides/subcommands.md),
+  [Lifecycle hooks](../guides/lifecycle_hooks.md),
+  [Constraints](../guides/constraints.md).

--- a/docs/cookbook/greeter.md
+++ b/docs/cookbook/greeter.md
@@ -1,0 +1,97 @@
+# Greeter: a single-command CLI
+
+A minimal complete example. One command, one required argument, three options
+(including a typed one with a validator and an env var fallback).
+
+Full runnable project: [`examples/greeter/`](https://github.com/joshrotenberg/cheer/tree/main/examples/greeter).
+
+## The command
+
+```elixir
+defmodule Greeter.CLI do
+  use Cheer.Command
+
+  command "greeter" do
+    about "Greet someone with style"
+    version "1.0.0"
+
+    argument :name, type: :string, required: true, help: "Who to greet"
+
+    option :greeting, type: :string, default: "Hello", env: "GREETER_GREETING",
+      help: "Greeting word"
+
+    option :loud, type: :boolean, short: :l, help: "SHOUT the greeting"
+
+    option :times, type: :integer, short: :n, default: 1,
+      validate: fn n -> if n in 1..10, do: :ok, else: {:error, "times must be 1-10"} end,
+      help: "Repeat the greeting"
+  end
+
+  @impl Cheer.Command
+  def run(%{name: name} = args, _raw) do
+    greeting = "#{args[:greeting]}, #{name}!"
+    greeting = if args[:loud], do: String.upcase(greeting), else: greeting
+
+    for _ <- 1..args[:times] do
+      IO.puts(greeting)
+    end
+
+    :ok
+  end
+
+  def main(argv) do
+    Cheer.run(__MODULE__, argv, prog: "greeter")
+  end
+end
+```
+
+## Run it
+
+```sh
+cd examples/greeter
+mix deps.get
+
+mix run -e 'Greeter.CLI.main(["world"])'
+# Hello, world!
+
+mix run -e 'Greeter.CLI.main(["world", "--loud", "--times", "3"])'
+# HELLO, WORLD!
+# HELLO, WORLD!
+# HELLO, WORLD!
+
+GREETER_GREETING=Hey mix run -e 'Greeter.CLI.main(["Ada"])'
+# Hey, Ada!
+
+mix run -e 'Greeter.CLI.main(["world", "--times", "42"])'
+# error: --times must be one of: ... (validator failure)
+
+mix run -e 'Greeter.CLI.main(["--help"])'
+# Usage: greeter <name> [OPTIONS]
+# ...
+```
+
+Or build as a proper escript:
+
+```sh
+mix escript.build
+./greeter world --loud --times 3
+```
+
+## What it shows
+
+- **Required positional** -- `argument :name, required: true` with the
+  missing-arg error path.
+- **Typed option with validator** -- `:times` is coerced to integer and
+  range-checked.
+- **Env var fallback** -- `GREETER_GREETING` is consulted when `--greeting`
+  is not passed.
+- **Short alias** -- `-l` for `--loud`, `-n` for `--times`.
+- **Version flag** -- `version "1.0.0"` wires up `-V` / `--version`.
+- **Auto help** -- `-h` / `--help` generated from the declaration.
+
+## See also
+
+- Guides: [Options](../guides/options.md), [Arguments](../guides/arguments.md),
+  [Validation](../guides/validation.md).
+- Next cookbook: [Devtool](devtool.md) -- multi-command nesting with
+  lifecycle hooks and groups.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,0 +1,72 @@
+# Getting Started
+
+Cheer is a clap-inspired CLI framework for Elixir. Define your command tree
+once, get parsing, validation, help, shell completion, a REPL, and in-process
+testing for free.
+
+## Install
+
+```elixir
+def deps do
+  [{:cheer, "~> 0.1"}]
+end
+```
+
+No runtime dependencies.
+
+## Five-minute tour
+
+A single-command CLI with an argument, a typed option, and a validator:
+
+```elixir
+defmodule MyApp.CLI.Greet do
+  use Cheer.Command
+
+  command "greet" do
+    about "Greet someone"
+
+    argument :name, type: :string, required: true, help: "Who to greet"
+    option :times, type: :integer, short: :n, default: 1,
+      validate: fn n -> if n in 1..10, do: :ok, else: {:error, "must be 1-10"} end,
+      help: "Repeat the greeting"
+  end
+
+  @impl Cheer.Command
+  def run(%{name: name, times: times}, _raw) do
+    for _ <- 1..times, do: IO.puts("Hello, #{name}!")
+  end
+end
+
+Cheer.run(MyApp.CLI.Greet, ["world", "--times", "3"], prog: "greet")
+# Hello, world!
+# Hello, world!
+# Hello, world!
+```
+
+`Cheer.run/3` takes your root command module, argv, and an optional `prog`
+name used in usage lines. A missing required argument, a bad integer, or
+`--times 42` would each produce a clear error and exit without running the
+handler.
+
+## Going further
+
+The guides are organized by feature; read them in any order.
+
+- [Concepts](concepts.md) -- vocabulary and mental model.
+- **Building blocks:**
+  [Options](guides/options.md),
+  [Arguments](guides/arguments.md),
+  [Subcommands](guides/subcommands.md).
+- **Validation and relationships:**
+  [Validation](guides/validation.md),
+  [Constraints](guides/constraints.md).
+- **Polish:**
+  [Help and output](guides/help_and_output.md),
+  [Lifecycle hooks](guides/lifecycle_hooks.md).
+- **Ecosystem:**
+  [Shell completion](guides/shell_completion.md),
+  [REPL mode](guides/repl.md),
+  [Testing](guides/testing.md).
+
+For full worked examples you can run locally, see the
+[cookbook](cookbook/greeter.md) and the matching projects under `examples/`.

--- a/docs/guides/arguments.md
+++ b/docs/guides/arguments.md
@@ -1,0 +1,89 @@
+# Arguments
+
+Positional inputs. Matched in declaration order.
+
+## Basic
+
+```elixir
+command "greet" do
+  argument :name, type: :string, required: true, help: "Who to greet"
+end
+```
+
+```
+greet world           # args[:name] == "world"
+greet                 # error: missing required argument(s): <name>
+```
+
+## Types and coercion
+
+```elixir
+argument :port,    type: :integer
+argument :ratio,   type: :float
+argument :enabled, type: :boolean
+argument :name,    type: :string   # default
+```
+
+## Optional arguments
+
+Omit `required: true` to make an argument optional. Optional arguments must
+follow all required ones in declaration order.
+
+```elixir
+argument :source, type: :string, required: true
+argument :dest,   type: :string   # optional
+```
+
+## Value placeholders
+
+Override the help-output name:
+
+```elixir
+argument :input, type: :string, value_name: "FILE"
+# Usage: convert <FILE>
+```
+
+## Trailing variadic args
+
+Collect an arbitrary number of trailing tokens under a named key:
+
+```elixir
+command "exec" do
+  argument :program, type: :string, required: true, help: "Program to run"
+  trailing_var_arg :args, help: "Arguments to pass through"
+end
+```
+
+```
+exec ls -- -la /tmp
+# args[:program] == "ls"
+# args[:args]    == ["-la", "/tmp"]
+```
+
+If `required: true` is set on `trailing_var_arg`, at least one token must be
+provided.
+
+Without a declared `trailing_var_arg`, tokens after `--` are available as
+`args[:rest]`.
+
+## Validation
+
+```elixir
+argument :port, type: :integer,
+  validate: fn p -> if p in 1024..65_535, do: :ok, else: {:error, "bad port"} end
+```
+
+See [Validation](validation.md) for more.
+
+## Hidden arguments
+
+```elixir
+argument :internal, type: :string, hide: true
+```
+
+Accepted by the parser; omitted from help output.
+
+## See also
+
+- [Options](options.md) -- non-positional flags.
+- [Help and output](help_and_output.md) -- `:display_order` for arguments.

--- a/docs/guides/constraints.md
+++ b/docs/guides/constraints.md
@@ -1,0 +1,114 @@
+# Constraints
+
+Relational rules between options: when something must be present, when things
+can coexist, when they cannot.
+
+## Conditional required
+
+### `:required_if`
+
+Required when another option holds a specific value:
+
+```elixir
+option :format, type: :string, choices: ["json", "table"]
+option :output, type: :string, required_if: [format: "json"]
+```
+
+```
+error: --output is required when --format is 'json'
+```
+
+Multiple conditions: any match triggers the requirement.
+
+```elixir
+option :region, type: :string, required_if: [env: "prod", env: "staging"]
+```
+
+### `:required_unless`
+
+Required unless any of the named options is present. Accepts an atom or a
+list:
+
+```elixir
+option :config, type: :string, required_unless: :inline
+option :config, type: :string, required_unless: [:inline, :stdin]
+```
+
+```
+error: --config is required unless --inline, --stdin is provided
+```
+
+## Per-option relations
+
+### `:conflicts_with`
+
+Declares that two options cannot be set together:
+
+```elixir
+option :json, type: :boolean, conflicts_with: :yaml
+option :json, type: :boolean, conflicts_with: [:yaml, :toml]
+```
+
+```
+error: --json cannot be used with --yaml
+```
+
+### `:requires`
+
+The inverse: setting one option implies another must also be set:
+
+```elixir
+option :user,   type: :string, requires: :password
+option :deploy, type: :boolean, requires: [:env, :region]
+```
+
+```
+error: --deploy requires --env
+```
+
+## Groups
+
+Group a set of options under a named constraint.
+
+### Mutually exclusive
+
+At most one of the group's options can be set:
+
+```elixir
+group :format, mutually_exclusive: true do
+  option :json, type: :boolean
+  option :csv,  type: :boolean
+  option :yaml, type: :boolean
+end
+```
+
+```
+error: options --json, --yaml are mutually exclusive (group: format)
+```
+
+### Co-occurring
+
+All or none of the group's options must be set:
+
+```elixir
+group :auth, co_occurring: true do
+  option :username, type: :string
+  option :password, type: :string
+end
+```
+
+```
+error: options --username, --password must be used together (group: auth)
+```
+
+## Picking the right tool
+
+- One option conditionally required based on another's **value**: `:required_if`.
+- One option required unless another is **present**: `:required_unless`.
+- Two or three specific options that must or must not coexist: `:conflicts_with`
+  / `:requires` on a single option.
+- A larger set of options with one constraint (format flags, auth flags):
+  `group` with `mutually_exclusive` or `co_occurring`.
+- Anything with its own logic: a cross-param `validate` function.
+
+See [Validation](validation.md) for the latter.

--- a/docs/guides/help_and_output.md
+++ b/docs/guides/help_and_output.md
@@ -1,0 +1,102 @@
+# Help and output
+
+Cheer generates help from the same metadata you use to declare the command.
+Customization is all opt-in.
+
+## Short vs long help
+
+Every command gets two help forms:
+
+- `-h` prints short help, built from `about` and `help` fields.
+- `--help` prints long help, preferring `long_about` over `about` and
+  `long_help` over `help` where those are set.
+
+```elixir
+command "deploy" do
+  about "Deploy to an environment"
+  long_about """
+  Deploy the current HEAD to a target environment. Accepts an environment
+  name and an optional region.
+  """
+end
+
+option :env, type: :string,
+  help: "Target environment",
+  long_help: "Target environment (one of: dev, staging, prod)"
+```
+
+## Before and after help
+
+Wrap the auto-generated output with fixed text:
+
+```elixir
+command "my-app" do
+  before_help "MyApp CLI\n"
+  after_help "Report issues at github.com/me/my-app"
+end
+```
+
+## Custom usage line
+
+Override the auto-generated usage:
+
+```elixir
+command "deploy" do
+  usage "my-app deploy [--env <ENV>] [--dry-run] [TARGET]"
+end
+```
+
+## Grouping options under headings
+
+Use `:help_heading` to put options under a custom section:
+
+```elixir
+option :host, type: :string, help_heading: "Network"
+option :port, type: :integer, help_heading: "Network"
+option :user, type: :string, help_heading: "Auth"
+option :pass, type: :string, help_heading: "Auth"
+```
+
+Default behavior: options without a heading appear first under `OPTIONS:`,
+then each custom heading appears in first-declaration order.
+
+## Display order
+
+Lower numbers appear first. Applies to options, arguments, and subcommands.
+
+```elixir
+option :verbose, type: :boolean, display_order: 1
+option :quiet,   type: :boolean, display_order: 2
+
+command "deploy" do
+  display_order 1
+end
+```
+
+Within any section, items without a `:display_order` fall back to
+declaration order. Stable sort, so mixing explicit and implicit ordering is
+predictable.
+
+## Hiding from help
+
+```elixir
+option :internal, type: :boolean, hide: true
+command "debug" do
+  hide true
+end
+```
+
+Still accepted by the parser; absent from help output.
+
+## Flag naming
+
+Cheer converts atom option names to kebab-case in both the parser and help
+output. `:base_port` becomes `--base-port` everywhere. You do not need to
+match them by hand.
+
+## See also
+
+- [Options](options.md) and [Arguments](arguments.md) for the declarations
+  these settings decorate.
+- [Subcommands](subcommands.md) for aliasing and prefix inference, both of
+  which show up in help output.

--- a/docs/guides/lifecycle_hooks.md
+++ b/docs/guides/lifecycle_hooks.md
@@ -1,0 +1,84 @@
+# Lifecycle hooks
+
+Run code before or after `run/2`. Handy for setup, teardown, logging, and
+sharing state across a command tree.
+
+## `before_run`
+
+Runs after all parsing and validation, just before `run/2`. Receives the
+`args` map, must return an `args` map.
+
+```elixir
+command "migrate" do
+  option :target, type: :string
+
+  before_run fn args ->
+    IO.puts("Connecting to database...")
+    args
+  end
+end
+```
+
+Use it to inject derived state into `args`, open connections, or log start
+events.
+
+## `after_run`
+
+Runs after `run/2` returns. Receives the return value, must return a value
+(typically the same one).
+
+```elixir
+after_run fn result ->
+  IO.puts("Done.")
+  result
+end
+```
+
+Useful for cleanup, timing, or unconditional logging.
+
+## `persistent_before_run` (inherited)
+
+Like `before_run`, but inherited by every descendant command. Declared on
+the root; runs for every subcommand invocation, before each command's own
+`before_run` hooks.
+
+```elixir
+command "my-tool" do
+  persistent_before_run fn args ->
+    Map.put(args, :start_time, System.monotonic_time(:millisecond))
+  end
+
+  subcommand MyTool.Server
+  subcommand MyTool.Db
+end
+```
+
+Every leaf-command handler under `my-tool` sees `args[:start_time]`.
+
+## Multiple hooks
+
+Each hook macro can be called more than once. Hooks run in declaration
+order.
+
+```elixir
+before_run &add_tracing/1
+before_run &add_logger/1
+before_run &add_timing/1
+```
+
+## Ordering
+
+For a subcommand invocation, the full ordering is:
+
+1. Every ancestor's `persistent_before_run` hooks, root-first.
+2. This command's `before_run` hooks, declaration order.
+3. `run/2`.
+4. This command's `after_run` hooks, declaration order.
+
+There is no `persistent_after_run` -- parent cleanup typically belongs in
+the root handler or in explicit supervision logic.
+
+## See also
+
+- [Subcommands](subcommands.md) for how persistent hooks flow through
+  nested trees.

--- a/docs/guides/options.md
+++ b/docs/guides/options.md
@@ -1,0 +1,105 @@
+# Options
+
+Flags accepted by a command. Long form is derived from the atom name
+(`:base_port` becomes `--base-port`); short aliases and every other behavior
+are opt-in.
+
+## Types
+
+```elixir
+option :port,    type: :integer
+option :ratio,   type: :float
+option :name,    type: :string     # default
+option :verbose, type: :boolean    # also supports --no-verbose
+option :v,       type: :count      # -vv -> 2
+```
+
+Typed values are coerced before your handler sees them. Invalid values
+produce an error and never reach `run/2`.
+
+## Short aliases
+
+```elixir
+option :port, type: :integer, short: :p
+```
+
+Accepts `-p 4000` or `--port 4000`.
+
+## Defaults and env var fallback
+
+```elixir
+option :port, type: :integer, default: 4000, env: "PORT"
+```
+
+Priority: CLI flag > `PORT` env var > default.
+
+## Choices
+
+```elixir
+option :format, type: :string, choices: ["json", "csv", "table"]
+```
+
+Rejected values produce an error before `run/2` runs.
+
+## Repeated flags (`:multi`)
+
+```elixir
+option :tag, type: :string, multi: true
+# --tag a --tag b  ->  args[:tag] == ["a", "b"]
+```
+
+Distinct from multi-value (consuming multiple tokens after one flag), which
+is tracked as a future feature.
+
+## Aliases (long-form)
+
+```elixir
+option :color, type: :string, aliases: [:colour]
+# --color red and --colour red both set args[:color]
+```
+
+## Global options
+
+Propagate an option to every subcommand:
+
+```elixir
+option :verbose, type: :boolean, global: true
+```
+
+Children inherit the option spec but can override by redeclaring.
+
+## Hiding options
+
+```elixir
+option :internal, type: :boolean, hide: true
+```
+
+Still accepted by the parser, not shown in help.
+
+## Boolean negation
+
+Every boolean option automatically accepts its `--no-<name>` inverse:
+
+```elixir
+option :color, type: :boolean, default: true
+
+# --color        -> true
+# --no-color     -> false
+```
+
+## Putting it together
+
+```elixir
+option :port, type: :integer, short: :p,
+  default: 4000, env: "PORT",
+  validate: fn p -> if p in 1024..65_535, do: :ok, else: {:error, "invalid port"} end,
+  help: "Port to listen on"
+```
+
+## See also
+
+- [Validation](validation.md) for `:validate` and cross-param validators.
+- [Constraints](constraints.md) for `:conflicts_with`, `:requires`,
+  `:required_if`, `:required_unless`, and groups.
+- [Help and output](help_and_output.md) for `:help_heading`, `:display_order`,
+  and other presentation controls.

--- a/docs/guides/repl.md
+++ b/docs/guides/repl.md
@@ -1,0 +1,56 @@
+# REPL mode
+
+Run your command tree as an interactive shell. Same parsing, same validation,
+same handlers.
+
+## Start it
+
+```elixir
+Cheer.Repl.start(MyApp.CLI.Root, prog: "my-app")
+```
+
+```
+my-app> greet world --loud
+HELLO, WORLD!
+my-app> db migrate --target 20240101
+Connecting to database...
+Migrating to version 20240101...
+my-app> help
+...
+my-app> exit
+```
+
+## Built-in commands
+
+- `help` / `?` -- print help for the root command (or a sub, with
+  `help <sub>`).
+- `exit` / `quit` / `Ctrl+D` -- leave the REPL.
+
+## Tokenization
+
+The REPL tokenizes each input line like a shell: whitespace-separated,
+single and double quotes supported, backslash escapes inside strings.
+
+```
+my-app> greet "Ada Lovelace" --loud
+my-app> run 'some command with spaces'
+```
+
+## Exit codes
+
+REPL mode doesn't exit the host process on errors -- a failed command
+prints its error and returns control to the prompt. That makes it safe to
+embed inside longer-running tools.
+
+## When to use it
+
+- Interactive admin tools for long-lived services.
+- Demo and teaching contexts where typing one command at a time beats
+  typing a full invocation each turn.
+- Workflows where you want the parser's validation without wrapping every
+  call in a subshell.
+
+## See also
+
+- [Testing](testing.md) -- `Cheer.Test.run/3` gives you the same
+  in-process execution without the interactive loop.

--- a/docs/guides/shell_completion.md
+++ b/docs/guides/shell_completion.md
@@ -1,0 +1,87 @@
+# Shell completion
+
+Cheer generates completion scripts for bash, zsh, fish, and PowerShell from
+the same command tree.
+
+## Generate
+
+```elixir
+Cheer.Completion.generate(MyApp.CLI.Root, :bash,       prog: "my-app")
+Cheer.Completion.generate(MyApp.CLI.Root, :zsh,        prog: "my-app")
+Cheer.Completion.generate(MyApp.CLI.Root, :fish,       prog: "my-app")
+Cheer.Completion.generate(MyApp.CLI.Root, :powershell, prog: "my-app")
+```
+
+All four return a string. Typical pattern: expose a hidden `completion`
+subcommand that prints the script, then instruct users to source it.
+
+```elixir
+defmodule MyApp.CLI.Completion do
+  use Cheer.Command
+
+  command "completion" do
+    about "Print a shell completion script"
+    argument :shell, type: :string, required: true, choices: ~w(bash zsh fish powershell)
+  end
+
+  @impl Cheer.Command
+  def run(%{shell: shell}, _raw) do
+    shell = String.to_existing_atom(shell)
+    IO.puts(Cheer.Completion.generate(MyApp.CLI.Root, shell, prog: "my-app"))
+  end
+end
+```
+
+## Installation (per shell)
+
+### bash
+
+```sh
+# One-shot for the current session:
+source <(my-app completion bash)
+
+# Permanent:
+my-app completion bash > ~/.bash_completion.d/my-app
+```
+
+### zsh
+
+```sh
+# In a directory on your fpath (e.g. ~/.zsh/completions):
+my-app completion zsh > ~/.zsh/completions/_my-app
+
+# Then in .zshrc:
+fpath=(~/.zsh/completions $fpath)
+autoload -U compinit && compinit
+```
+
+### fish
+
+```sh
+my-app completion fish > ~/.config/fish/completions/my-app.fish
+```
+
+### PowerShell
+
+```powershell
+# One-shot for the current session:
+my-app completion powershell | Out-String | Invoke-Expression
+
+# Permanent: append to $PROFILE
+my-app completion powershell >> $PROFILE
+```
+
+## What gets completed
+
+- Declared subcommands at each level of the tree.
+- Long-form options (`--port`, `--no-verbose`) and short aliases (`-p`).
+- For boolean options, the `--no-<name>` negation is included.
+- `--help` is always in the completion set.
+
+Value completion for option arguments (e.g. suggesting from `:choices`) is a
+future enhancement.
+
+## See also
+
+- [Subcommands](subcommands.md) -- the tree that drives what gets completed.
+- [Options](options.md) -- flag names, short aliases, boolean negation.

--- a/docs/guides/subcommands.md
+++ b/docs/guides/subcommands.md
@@ -1,0 +1,152 @@
+# Subcommands
+
+Commands compose. Any command can register child modules as subcommands,
+producing a tree of arbitrary depth.
+
+## Basic nesting
+
+```elixir
+defmodule Devtool.CLI do
+  use Cheer.Command
+
+  command "devtool" do
+    about "Developer toolkit"
+
+    subcommand Devtool.Server
+    subcommand Devtool.Db
+  end
+end
+
+defmodule Devtool.Server do
+  use Cheer.Command
+
+  command "server" do
+    about "Server management"
+
+    subcommand Devtool.Server.Start
+    subcommand Devtool.Server.Stop
+  end
+end
+```
+
+Each subcommand is a full command module with its own options, arguments,
+help, and optional children.
+
+## Require a subcommand
+
+By default, invoking a parent command with no child shows help. To treat
+that as an error instead:
+
+```elixir
+command "devtool" do
+  subcommand_required true
+  # ...
+end
+```
+
+## Aliases
+
+```elixir
+defmodule MyApp.CLI.Checkout do
+  use Cheer.Command
+
+  command "checkout" do
+    aliases ["co", "ck"]
+    # ...
+  end
+end
+```
+
+`my-app co`, `my-app ck`, and `my-app checkout` all resolve to the same
+module.
+
+## Prefix inference
+
+Allow any unambiguous prefix to resolve to a declared subcommand:
+
+```elixir
+command "git" do
+  infer_subcommands true
+
+  subcommand MyApp.CLI.Checkout
+  subcommand MyApp.CLI.Status
+end
+```
+
+```
+git sta      -> status
+git che      -> error: 'che' is ambiguous; candidates: check, checkout
+```
+
+Exact matches always win over prefix inference. Aliases are not
+prefix-matched.
+
+## "Did you mean?"
+
+Unknown subcommands produce a typo suggestion:
+
+```
+$ my-app chekout
+error: unknown command 'chekout'
+
+  Did you mean 'checkout'?
+```
+
+Suggestions are ranked by Jaro distance and gated at 0.7 similarity.
+
+## External subcommands (plugins)
+
+Let a command accept unknown subcommand tokens and surface them to
+`run/2`. Enables git-style plugin dispatchers:
+
+```elixir
+command "my-tool" do
+  external_subcommands true
+  subcommand MyApp.CLI.Status   # declared subs still take precedence
+end
+
+@impl Cheer.Command
+def run(args, _raw) do
+  case args[:external_subcommand] do
+    {name, rest} -> System.cmd("my-tool-#{name}", rest)
+    nil          -> :ok
+  end
+end
+```
+
+Behavior:
+
+- Declared subcommands match first.
+- First non-option token not matching a declared sub becomes the external
+  subcommand name. Everything after it passes through verbatim, including
+  flags the parent does not know about.
+- `args[:external_subcommand]` is `nil` when no external sub was invoked,
+  `{name, rest}` when one was. Pattern matches are total.
+
+## Propagating version
+
+By default only the root's `-V` / `--version` prints its version. To share
+with children:
+
+```elixir
+command "my-tool" do
+  version "1.0.0"
+  propagate_version true
+end
+```
+
+## Help for a specific subcommand
+
+All of these show the same help:
+
+```
+my-tool server start --help
+my-tool server start -h
+my-tool help server start
+```
+
+## See also
+
+- [Lifecycle hooks](lifecycle_hooks.md) for `persistent_before_run`, which
+  applies to every descendant.
+- [Help and output](help_and_output.md) for `display_order` on subcommands.

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -1,0 +1,77 @@
+# Testing
+
+Cheer ships an in-process test runner that captures output and returns the
+handler's return value. No subprocess, no argv escaping, no port juggling.
+
+## Basic
+
+```elixir
+test "greet prints a greeting" do
+  result = Cheer.Test.run(MyApp.CLI.Greet, ["world"])
+
+  assert result.return == :ok
+  assert result.output =~ "Hello, world!"
+end
+```
+
+`Cheer.Test.run/3` takes the same arguments as `Cheer.run/3`: a command
+module, argv, and an optional `prog`.
+
+## Return shape
+
+```elixir
+%Cheer.Test{
+  return: term(),       # whatever your run/2 returned (or :ok if cheer handled an error)
+  output: String.t()    # everything written to stdout during the invocation
+}
+```
+
+## Testing validation failures
+
+When validation fails, cheer prints an error and does not invoke `run/2`.
+Assert on the captured output:
+
+```elixir
+test "rejects out-of-range times" do
+  result = Cheer.Test.run(MyApp.CLI.Greet, ["world", "--times", "100"])
+
+  assert result.output =~ "must be 1-10"
+  refute result.output =~ "Hello"
+end
+```
+
+## Testing subcommand routing
+
+```elixir
+test "db migrate with a target" do
+  result = Cheer.Test.run(Devtool.CLI, ["db", "migrate", "--target", "20240101"])
+
+  assert result.output =~ "Migrating to version 20240101"
+end
+```
+
+Same as production: the router walks the tree, parses each level's options,
+and dispatches to the leaf's `run/2`.
+
+## Testing help output
+
+```elixir
+test "help includes all subcommands" do
+  result = Cheer.Test.run(Devtool.CLI, ["--help"])
+
+  assert result.output =~ "server"
+  assert result.output =~ "db"
+end
+```
+
+## Integration tests
+
+For end-to-end tests that exercise the real escript binary, use the
+usual `System.cmd/2` against your built artifact. Cheer's test runner
+is for fast, in-process unit tests of parsing and handler logic, not
+for testing the escript launcher itself.
+
+## See also
+
+- [REPL mode](repl.md) -- interactive equivalent of the in-process
+  runner.

--- a/docs/guides/validation.md
+++ b/docs/guides/validation.md
@@ -1,0 +1,76 @@
+# Validation
+
+Three layers: type coercion (automatic), per-param validation (inline), and
+cross-param validation (after all args are parsed).
+
+## Per-param: choices
+
+The cheapest form. Enumerate the accepted values:
+
+```elixir
+option :format, type: :string, choices: ["json", "csv", "table"]
+```
+
+Rejected values produce `error: --format must be one of: json, csv, table`.
+
+Also works on arguments:
+
+```elixir
+argument :env, type: :string, choices: ["dev", "staging", "prod"]
+```
+
+## Per-param: inline validator
+
+Any function that returns `:ok` or `{:error, message}`:
+
+```elixir
+option :port, type: :integer,
+  validate: fn p ->
+    if p in 1024..65_535, do: :ok, else: {:error, "port must be 1024-65535"}
+  end
+```
+
+Runs after type coercion, so the value you receive is already the declared
+type.
+
+## Cross-param validators
+
+Run after every option and argument has been parsed. Receives the full
+`args` map.
+
+```elixir
+validate fn args ->
+  cond do
+    args[:tls] and is_nil(args[:cert]) -> {:error, "--tls requires --cert"}
+    args[:since] && args[:until] && args[:since] > args[:until] ->
+      {:error, "--since must be before --until"}
+    true -> :ok
+  end
+end
+```
+
+You can declare multiple `validate` blocks per command. They run in
+declaration order; the first `{:error, ...}` halts the pipeline.
+
+## Order of evaluation
+
+For a single invocation, validation runs in this order:
+
+1. Type coercion (automatic, based on `:type`).
+2. Defaults and env var fallback.
+3. Required-argument and required-option checks.
+4. Choices (`:choices`).
+5. Per-param `:validate` functions.
+6. Cross-param validators (`validate fn args -> ... end`).
+7. Conditional-required (`:required_if`, `:required_unless`).
+8. Per-option constraints (`:conflicts_with`, `:requires`).
+9. Group constraints (`mutually_exclusive`, `co_occurring`).
+
+The first failure halts; your `run/2` is only called if everything passes.
+
+## See also
+
+- [Constraints](constraints.md) for conditional-required, conflicts, requires,
+  and groups.
+- [Options](options.md) and [Arguments](arguments.md) for the declarations
+  validation operates on.

--- a/mix.exs
+++ b/mix.exs
@@ -52,15 +52,37 @@ defmodule Cheer.MixProject do
     [
       licenses: ["MIT"],
       links: %{"GitHub" => @source_url},
-      files: ~w(lib .formatter.exs mix.exs README.md LICENSE)
+      files: ~w(lib docs .formatter.exs mix.exs README.md LICENSE CHANGELOG.md)
     ]
   end
 
   defp docs do
     [
-      main: "Cheer",
+      main: "getting_started",
       source_ref: "v#{@version}",
-      source_url: @source_url
+      source_url: @source_url,
+      extras: [
+        "docs/getting_started.md",
+        "docs/concepts.md",
+        "docs/guides/options.md",
+        "docs/guides/arguments.md",
+        "docs/guides/subcommands.md",
+        "docs/guides/validation.md",
+        "docs/guides/constraints.md",
+        "docs/guides/help_and_output.md",
+        "docs/guides/lifecycle_hooks.md",
+        "docs/guides/shell_completion.md",
+        "docs/guides/repl.md",
+        "docs/guides/testing.md",
+        "docs/cookbook/greeter.md",
+        "docs/cookbook/devtool.md",
+        "CHANGELOG.md"
+      ],
+      groups_for_extras: [
+        "Getting Started": ~r{^docs/(getting_started|concepts)\.md$},
+        Guides: ~r{^docs/guides/.*\.md$},
+        Cookbook: ~r{^docs/cookbook/.*\.md$}
+      ]
     ]
   end
 end


### PR DESCRIPTION
Restructures documentation into three tiers rendered on hexdocs, inspired by the clap and Clikt information architecture.

## Why

README had grown to ~220 lines doing triple duty: marketing pitch, tutorial, and feature-by-feature reference. Each section was tight, but there was no obvious landing/progression path, and every new feature added a new section. This splits responsibilities:

- README: pitch + 30-second taste + pointers. Stays small.
- Guides: one page per feature area, discoverable from the sidebar.
- Cookbook: full worked examples, each backed by a runnable project under \`examples/\`.

## Structure

\`\`\`
docs/
  getting_started.md       # Install + five-minute tour
  concepts.md              # Vocabulary (commands/options/args/subs)
  guides/
    options.md
    arguments.md
    subcommands.md         # includes external_subcommands
    validation.md
    constraints.md
    help_and_output.md
    lifecycle_hooks.md
    shell_completion.md    # includes PowerShell
    repl.md
    testing.md
  cookbook/
    greeter.md             # -> examples/greeter/
    devtool.md             # -> examples/devtool/
\`\`\`

Guides cross-link to each other via \`See also\` sections. Cookbook pages link back to the relevant guides.

## mix.exs changes

\`\`\`elixir
defp docs do
  [
    main: \"getting_started\",
    source_ref: \"v#{@version}\",
    source_url: @source_url,
    extras: [
      \"docs/getting_started.md\",
      \"docs/concepts.md\",
      # ... all guides + cookbook pages ...
      \"CHANGELOG.md\"
    ],
    groups_for_extras: [
      \"Getting Started\": ~r{^docs/(getting_started|concepts)\.md\$},
      Guides:              ~r{^docs/guides/.*\.md\$},
      Cookbook:            ~r{^docs/cookbook/.*\.md\$}
    ]
  ]
end
\`\`\`

\`main\` now points at the getting-started guide rather than the \`Cheer\` module docs -- matches what clap and Clikt do, and means the landing page is narrative rather than an API reference the first-time visitor doesn't have context for yet.

Package \`:files\` extended to include \`docs/\` and \`CHANGELOG.md\` so the docs ship in the hex tarball.

## What did not change

- Zero code changes -- no API, no behavior.
- Examples under \`examples/\` unchanged -- they were already good, now they have explicit cookbook write-ups pointing at them.
- Module \`@moduledoc\`s unchanged -- the guides complement the API reference rather than replacing it.

## Follow-ups (not in this PR)

Per the plan we agreed on, this ships the restructure + content migration. Additional cookbook entries will land in follow-up PRs:

- \`git_like\` -- dogfoods \`external_subcommands\` (#25, just shipped).
- \`find_like\` -- exercises \`trailing_var_arg\`.
- Possibly \`interactive_repl\` if the REPL wants a dedicated walkthrough.

## Verification

\`\`\`
\$ mix docs
Generating docs...
View html docs at \"doc/index.html\"

\$ mix test
200 tests, 0 failures

\$ mix format --check-formatted
(clean)

\$ mix credo --strict
Analysis took 0.1 seconds -- 260 mods/funs, found no issues.

\$ mix hex.build --unpack
# Confirms docs/ and CHANGELOG.md are in the package tarball.
\`\`\`

Eyeballed the rendered hexdocs locally: sidebar groups show as \"Getting Started\", \"Guides\", \"Cookbook\"; all cross-page links resolve; code blocks syntax-highlight.