### PR TITLE
chore: ignore example escript binaries and enrich hex links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@ CLAUDE.md
 examples/*/_build/
 examples/*/deps/
 examples/*/mix.lock
+
+# Compiled escript binaries (mix escript.build output, named after the app)
+examples/devtool/devtool
+examples/greeter/greeter

--- a/mix.exs
+++ b/mix.exs
@@ -51,7 +51,11 @@ defmodule Cheer.MixProject do
   defp package do
     [
       licenses: ["MIT"],
-      links: %{"GitHub" => @source_url},
+      links: %{
+        "GitHub" => @source_url,
+        "Changelog" => "#{@source_url}/blob/main/CHANGELOG.md",
+        "Documentation" => "https://hexdocs.pm/cheer"
+      },
       files: ~w(lib docs .formatter.exs mix.exs README.md LICENSE CHANGELOG.md)
     ]
   end


### PR DESCRIPTION
## What

Two small housekeeping changes.

### gitignore example escript binaries

`mix escript.build` in the example projects emits a compiled binary named after the app (`examples/devtool/devtool`, `examples/greeter/greeter`). These were showing up as untracked. Added explicit ignore rules alongside the existing `examples/*/_build` etc. entries.

### Enrich hex package links

The package `links` map only had GitHub, so the hex.pm Links section was sparse. Added:

- `Changelog` -> `CHANGELOG.md` on main
- `Documentation` -> `https://hexdocs.pm/cheer`

Docs are already published (`has_docs: true`, `cheer.hexdocs.pm` is live), so hex.pm already auto-links docs; this makes the Links box explicit and adds the changelog. Takes effect on the next publish.

## Verification

- `mix compile` clean
- `mix format --check-formatted` clean