### PR TITLE
fix: evaluate option/argument opt values instead of storing AST

### DIFF
--- a/lib/cheer/command/dsl.ex
+++ b/lib/cheer/command/dsl.ex
@@ -107,7 +107,7 @@ defmodule Cheer.Command.DSL do
   """
   defmacro trailing_var_arg(name, opts \\ []) do
     quote do
-      @cheer_trailing_var_arg {unquote(name), unquote(Macro.escape(opts))}
+      @cheer_trailing_var_arg {unquote(name), unquote(opts)}
     end
   end
 
@@ -135,13 +135,13 @@ defmodule Cheer.Command.DSL do
       fname = :"__cheer_validate_#{name}__"
 
       quote do
-        @cheer_arguments {unquote(name), unquote(Macro.escape(clean_opts))}
+        @cheer_arguments {unquote(name), unquote(clean_opts)}
         @cheer_has_validate unquote(name)
         def unquote(fname)(val), do: unquote(validate_ast).(val)
       end
     else
       quote do
-        @cheer_arguments {unquote(name), unquote(Macro.escape(clean_opts))}
+        @cheer_arguments {unquote(name), unquote(clean_opts)}
       end
     end
   end
@@ -186,13 +186,13 @@ defmodule Cheer.Command.DSL do
         fname = :"__cheer_validate_#{name}__"
 
         quote do
-          @cheer_options {unquote(name), unquote(Macro.escape(clean_opts))}
+          @cheer_options {unquote(name), unquote(clean_opts)}
           @cheer_has_validate unquote(name)
           def unquote(fname)(val), do: unquote(validate_ast).(val)
         end
       else
         quote do
-          @cheer_options {unquote(name), unquote(Macro.escape(clean_opts))}
+          @cheer_options {unquote(name), unquote(clean_opts)}
         end
       end
 

--- a/test/cheer_test.exs
+++ b/test/cheer_test.exs
@@ -525,6 +525,45 @@ defmodule CheerTest do
     end
   end
 
+  # -- Non-literal opt values (issue #48) --------------------------------------
+
+  defmodule TestSigilChoices do
+    use Cheer.Command
+
+    command "effort" do
+      about("Sigil choices")
+
+      option(:effort, type: :string, choices: ~w(low medium high), help: "Effort level")
+      argument(:tag, type: :string, choices: ~w(a b c), required: false, help: "Tag")
+    end
+
+    @impl Cheer.Command
+    def run(args, _raw), do: {:ok, args}
+  end
+
+  describe "non-literal opt values (issue #48)" do
+    test "~w(...) opt values evaluate instead of being stored as AST" do
+      meta = TestSigilChoices.__cheer_meta__()
+      {:effort, option_opts} = Enum.find(meta.options, fn {n, _} -> n == :effort end)
+      {:tag, arg_opts} = Enum.find(meta.arguments, fn {n, _} -> n == :tag end)
+
+      assert Keyword.get(option_opts, :choices) == ["low", "medium", "high"]
+      assert Keyword.get(arg_opts, :choices) == ["a", "b", "c"]
+    end
+
+    test "~w(...) choices render in help without crashing" do
+      output = capture_io(fn -> Cheer.run(TestSigilChoices, ["--help"]) end)
+      assert output =~ "low"
+      assert output =~ "medium"
+      assert output =~ "high"
+    end
+
+    test "~w(...) choices are enforced at validation time" do
+      output = capture_io(fn -> Cheer.run(TestSigilChoices, ["--effort", "extreme"]) end)
+      assert output =~ "must be one of"
+    end
+  end
+
   # -- Cross-param validation --------------------------------------------------
 
   defmodule TestCrossValidation do


### PR DESCRIPTION
Closes #48.

## Problem

`option/2` and `argument/2` ran `Macro.escape/1` over the opts keyword list before stashing it in a module attribute. For a literal value the escaped AST equals the value, so it round-trips. For a non-literal such as the common `choices: ~w(low medium high)`, `Macro.escape` preserves the `{:sigil_w, ...}` call node verbatim, so at runtime the opt held that AST tuple rather than `["low", "medium", "high"]`.

`mycli --help` then crashed:

```
** (Protocol.UndefinedError) protocol Enumerable not implemented for Tuple
    {:sigil_w, [...], [...]}
    lib/cheer/help.ex:251: Cheer.Help.format_option/2
```

## Fix

Emit `unquote(clean_opts)` instead of `unquote(Macro.escape(clean_opts))` so each opt value is evaluated at compile time in the module body. This is exactly what the `group/3` macro already does with its opts. `trailing_var_arg/2` had the same pattern and gets the same fix.

`~w(...)`, module constants, and any other constant expression now resolve to their value instead of being frozen as AST.

## Tests

Added a `non-literal opt values` describe block:
- `~w(...)` opt values evaluate (asserted against `__cheer_meta__`) for both an option and an argument
- `~w(...)` choices render in `--help` without crashing
- `~w(...)` choices are enforced at validation time

Full suite: 203 passing (was 200).