### PR TITLE
feat: num_args for multi-value options

### DIFF
--- a/lib/cheer/command/dsl.ex
+++ b/lib/cheer/command/dsl.ex
@@ -156,6 +156,11 @@ defmodule Cheer.Command.DSL do
     * `:required` - `true` or `false` (default)
     * `:default` - default value when not provided (`:count` defaults to `0`, `:multi` defaults to `[]`)
     * `:multi` - `true` to allow repeated flags collected into a list (e.g. `--tag a --tag b`)
+    * `:num_args` - collect several values from a single flag invocation into a list:
+      an integer for an exact count (`num_args: 2` accepts `--point 1 2`) or a range
+      for a variable count (`num_args: 1..3`). Collection stops at the next flag or
+      `--`. Distinct from `:multi`, which repeats the flag. An out-of-range count is a
+      usage error.
     * `:env` - environment variable name to read as fallback
     * `:choices` - list of allowed values
     * `:help` - help text shown in `--help`

--- a/lib/cheer/help.ex
+++ b/lib/cheer/help.ex
@@ -269,6 +269,12 @@ defmodule Cheer.Help do
         do: suffixes ++ ["(global)"],
         else: suffixes
 
+    suffixes =
+      case Keyword.get(opt_opts, :num_args) do
+        nil -> suffixes
+        spec -> suffixes ++ [num_args_label(spec)]
+      end
+
     suffix = if suffixes != [], do: " " <> Enum.join(suffixes, " "), else: ""
 
     "  #{short}--#{String.pad_trailing(flag_name <> value_suffix, 16)} #{help}#{suffix}"
@@ -280,6 +286,9 @@ defmodule Cheer.Help do
   # get "unknown option".
   defp flag_from(name) when is_atom(name), do: name |> Atom.to_string() |> flag_from()
   defp flag_from(name) when is_binary(name), do: String.replace(name, "_", "-")
+
+  defp num_args_label(n) when is_integer(n), do: "(#{n} values)"
+  defp num_args_label(%Range{first: first, last: last}), do: "(#{first}..#{last} values)"
 
   defp format_usage(meta, prog) do
     parts = ["Usage: #{prog}"]

--- a/lib/cheer/router.ex
+++ b/lib/cheer/router.ex
@@ -211,7 +211,15 @@ defmodule Cheer.Router do
 
     all_options = meta.options ++ inherited_globals
 
-    {option_parser_opts, option_aliases} = build_option_parser_spec(all_options)
+    # Options declared with `num_args:` accept several values per flag, which
+    # OptionParser cannot express. Pull them (and their value tokens) out of
+    # argv up front, then parse the remainder normally.
+    {num_args_values, argv} = extract_num_args(argv, all_options)
+
+    parser_options =
+      Enum.reject(all_options, fn {_name, o} -> Keyword.has_key?(o, :num_args) end)
+
+    {option_parser_opts, option_aliases} = build_option_parser_spec(parser_options)
 
     {parsed, positional, invalid} =
       OptionParser.parse(argv, strict: option_parser_opts, aliases: option_aliases)
@@ -223,6 +231,7 @@ defmodule Cheer.Router do
       args = apply_defaults(all_options)
       args = apply_env_vars(args, all_options)
       args = Map.merge(args, build_parsed_map(parsed, all_options))
+      args = Map.merge(args, num_args_values)
 
       {declared_positional, rest_args} = Enum.split(positional, length(meta.arguments))
 
@@ -262,7 +271,8 @@ defmodule Cheer.Router do
           :handled
 
         true ->
-          with :ok <- validate_conditional_required(args, all_options),
+          with :ok <- validate_num_args(num_args_values, all_options),
+               :ok <- validate_conditional_required(args, all_options),
                :ok <- validate_constraints(args, all_options),
                :ok <- validate_groups(args, Map.get(meta, :groups, %{})),
                :ok <- validate_params(args, all_options),
@@ -660,6 +670,137 @@ defmodule Cheer.Router do
     IO.puts("error: '#{token}' is ambiguous")
     IO.puts("candidates: #{Enum.join(candidates, ", ")}")
   end
+
+  # -- num_args (multi-value options) --
+
+  # Collect values for options declared with `num_args:`. OptionParser binds a
+  # single value per flag, so `--point 1 2 3` would otherwise leave "2" and "3"
+  # as positionals. This pulls the matched flag and up to `max` following value
+  # tokens out of argv and returns `{%{point: [1, 2, 3]}, residual_argv}`.
+  # Collection stops at the next flag-looking token (one starting with "-"),
+  # at "--", or once `max` values are taken.
+  defp extract_num_args(argv, options) do
+    num_args_opts = Enum.filter(options, fn {_name, o} -> Keyword.has_key?(o, :num_args) end)
+
+    if num_args_opts == [] do
+      {%{}, argv}
+    else
+      do_extract_num_args(argv, num_args_lookup(num_args_opts), %{}, [])
+    end
+  end
+
+  defp num_args_lookup(num_args_opts) do
+    Enum.flat_map(num_args_opts, fn {name, opts} = entry ->
+      long = [{"--#{flag_string(name)}", entry}]
+
+      short =
+        case Keyword.get(opts, :short) do
+          nil -> []
+          s -> [{"-#{s}", entry}]
+        end
+
+      aliases =
+        Enum.map(Keyword.get(opts, :aliases, []), fn a -> {"--#{flag_string(a)}", entry} end)
+
+      long ++ short ++ aliases
+    end)
+    |> Map.new()
+  end
+
+  defp do_extract_num_args([], _lookup, collected, residual),
+    do: {collected, Enum.reverse(residual)}
+
+  defp do_extract_num_args(["--" | rest], _lookup, collected, residual),
+    do: {collected, Enum.reverse(residual) ++ ["--" | rest]}
+
+  defp do_extract_num_args([token | rest], lookup, collected, residual) do
+    case num_args_flag(token, lookup) do
+      {{name, opts}, inline} ->
+        {_min, max} = num_args_bounds(Keyword.fetch!(opts, :num_args))
+
+        {raw_values, rest2} =
+          case inline do
+            nil -> take_num_args_values(rest, max, [])
+            value -> {[value], rest}
+          end
+
+        values = Enum.map(raw_values, &coerce_arg(&1, opts))
+        do_extract_num_args(rest2, lookup, Map.put(collected, name, values), residual)
+
+      :nomatch ->
+        do_extract_num_args(rest, lookup, collected, [token | residual])
+    end
+  end
+
+  # Resolve a token to a num_args option. Returns `{entry, inline_value}` where
+  # inline_value is the part after `=` for the `--flag=value` form, or nil for
+  # the space-separated form.
+  defp num_args_flag(token, lookup) do
+    cond do
+      Map.has_key?(lookup, token) ->
+        {Map.fetch!(lookup, token), nil}
+
+      String.starts_with?(token, "--") and String.contains?(token, "=") ->
+        [flag, value] = String.split(token, "=", parts: 2)
+
+        case Map.fetch(lookup, flag) do
+          {:ok, entry} -> {entry, value}
+          :error -> :nomatch
+        end
+
+      true ->
+        :nomatch
+    end
+  end
+
+  defp take_num_args_values(tokens, max, acc) when length(acc) >= max,
+    do: {Enum.reverse(acc), tokens}
+
+  defp take_num_args_values([], _max, acc), do: {Enum.reverse(acc), []}
+
+  defp take_num_args_values(["--" | _] = tokens, _max, acc),
+    do: {Enum.reverse(acc), tokens}
+
+  defp take_num_args_values([token | rest], max, acc) do
+    if String.starts_with?(token, "-") and token != "-" do
+      {Enum.reverse(acc), [token | rest]}
+    else
+      take_num_args_values(rest, max, [token | acc])
+    end
+  end
+
+  defp validate_num_args(num_args_values, options) do
+    Enum.reduce_while(num_args_values, :ok, fn {name, values}, _acc ->
+      case Keyword.fetch(Keyword.get(options, name, []), :num_args) do
+        :error ->
+          {:cont, :ok}
+
+        {:ok, spec} ->
+          {min, max} = num_args_bounds(spec)
+          got = length(values)
+
+          if got >= min and got <= max do
+            {:cont, :ok}
+          else
+            {:halt, {:error, num_args_error(name, min, max, got)}}
+          end
+      end
+    end)
+  end
+
+  defp num_args_bounds(n) when is_integer(n), do: {n, n}
+
+  defp num_args_bounds(%Range{first: first, last: last}),
+    do: {min(first, last), max(first, last)}
+
+  defp num_args_error(name, min, max, got) when min == max,
+    do: "--#{flag_string(name)} expects #{min} value(s), got #{got}"
+
+  defp num_args_error(name, min, max, got),
+    do: "--#{flag_string(name)} expects between #{min} and #{max} values, got #{got}"
+
+  defp flag_string(name) when is_atom(name),
+    do: name |> Atom.to_string() |> String.replace("_", "-")
 
   # -- OptionParser spec --
 

--- a/test/cheer_test.exs
+++ b/test/cheer_test.exs
@@ -564,6 +564,70 @@ defmodule CheerTest do
     end
   end
 
+  # -- num_args / multi-value options (issue #27) ------------------------------
+
+  defmodule TestNumArgs do
+    use Cheer.Command
+
+    command "plot" do
+      about("num_args")
+
+      argument(:label, type: :string, required: false, help: "Label")
+      option(:point, type: :integer, num_args: 2, short: :p, help: "Two coords")
+      option(:tags, type: :string, num_args: 1..3, help: "One to three tags")
+      option(:verbose, type: :boolean, help: "Verbose")
+    end
+
+    @impl Cheer.Command
+    def run(args, _raw), do: {:ok, args}
+  end
+
+  describe "num_args (issue #27)" do
+    test "exact count collects and coerces values" do
+      assert {:ok, %{point: [1, 2]}} = Cheer.run(TestNumArgs, ["--point", "1", "2"])
+    end
+
+    test "exact count via short flag" do
+      assert {:ok, %{point: [1, 2]}} = Cheer.run(TestNumArgs, ["-p", "1", "2"])
+    end
+
+    test "too few values is a usage error" do
+      output = capture_io(fn -> Cheer.run(TestNumArgs, ["--point", "1"]) end)
+      assert output =~ "--point expects 2 value(s), got 1"
+    end
+
+    test "extra values beyond the max fall through to positionals" do
+      assert {:ok, %{point: [1, 2], label: "3"}} =
+               Cheer.run(TestNumArgs, ["--point", "1", "2", "3"])
+    end
+
+    test "range accepts a variable count" do
+      assert {:ok, %{tags: ["a"]}} = Cheer.run(TestNumArgs, ["--tags", "a"])
+      assert {:ok, %{tags: ["a", "b", "c"]}} = Cheer.run(TestNumArgs, ["--tags", "a", "b", "c"])
+    end
+
+    test "collection stops at the next flag" do
+      assert {:ok, %{tags: ["a"], verbose: true}} =
+               Cheer.run(TestNumArgs, ["--tags", "a", "--verbose"])
+    end
+
+    test "values do not leak into a declared positional" do
+      assert {:ok, %{point: [1, 2], label: "site"}} =
+               Cheer.run(TestNumArgs, ["site", "--point", "1", "2"])
+    end
+
+    test "--flag=value inline form yields a single value" do
+      output = capture_io(fn -> Cheer.run(TestNumArgs, ["--point=1"]) end)
+      assert output =~ "--point expects 2 value(s), got 1"
+    end
+
+    test "help labels the value count" do
+      output = capture_io(fn -> Cheer.run(TestNumArgs, ["--help"]) end)
+      assert output =~ "(2 values)"
+      assert output =~ "(1..3 values)"
+    end
+  end
+
   # -- Cross-param validation --------------------------------------------------
 
   defmodule TestCrossValidation do


### PR DESCRIPTION
Closes #27.

## What

Adds `num_args:` to options, collecting several values from a single flag invocation into a list:

```elixir
option :point, type: :integer, num_args: 2      # --point 1 2     -> [1, 2]
option :tags,  type: :string,  num_args: 1..3   # --tags a b c    -> ["a", "b", "c"]
```

This is distinct from `:multi`, which repeats the flag (`--tag a --tag b`).

## How

`OptionParser` binds a single value per flag, so `--point 1 2 3` would leave `2` and `3` as positionals. num_args options are pulled out of argv before `OptionParser` runs:

- The matched flag (long, short, or alias; `--flag value...` or `--flag=value`) and up to `max` following value tokens are collected.
- Collection stops at the next flag-looking token (one starting with `-`), at `--`, or once `max` is reached.
- Values are coerced to the option's `:type`.
- The remaining argv parses normally, so collected values never leak into positional arguments.

An out-of-range count is a usage error: `--point expects 2 value(s), got 1`. Help labels the count as `(2 values)` / `(1..3 values)`.

Builds on #48: `num_args: 1..3` now evaluates to a real `Range` at compile time (previously it would have been frozen as AST), which the runtime pattern-matches.

## Tests

A `num_args` describe block covering: exact count, short flag, too-few error, extra-values-fall-through-to-positionals, range min/max, stop-at-next-flag, no-leak-into-positional, `--flag=value` inline form, and help labeling. Full suite 212 passing (was 203). Credo and Dialyzer clean.