### PR TITLE
feat: signal usage failures so callers can set an exit code

### DIFF
--- a/docs/guides/help_and_output.md
+++ b/docs/guides/help_and_output.md
@@ -94,6 +94,30 @@ Cheer converts atom option names to kebab-case in both the parser and help
 output. `:base_port` becomes `--base-port` everywhere. You do not need to
 match them by hand.
 
+## Exit codes
+
+`Cheer.run/3` returns the matched command's own `run/2` value on success. On a
+usage failure (unknown option, missing required argument, bad choice, unknown
+or ambiguous subcommand, missing required subcommand) it prints the error and
+returns `{:error, :usage}`. `--help` and `--version` return `:ok`.
+
+To map that to a process exit code, either branch on the return value:
+
+```elixir
+def main(argv) do
+  case Cheer.run(MyApp.CLI, argv) do
+    {:error, :usage} -> System.halt(2)
+    _ -> :ok
+  end
+end
+```
+
+or let `Cheer.main/3` halt for you with conventional codes (`0` ok, `2` usage):
+
+```elixir
+def main(argv), do: Cheer.main(MyApp.CLI, argv, prog: "myapp")
+```
+
 ## See also
 
 - [Options](options.md) and [Arguments](arguments.md) for the declarations

--- a/lib/cheer.ex
+++ b/lib/cheer.ex
@@ -42,11 +42,44 @@ defmodule Cheer do
 
   Options:
     * `:prog` - program name for usage lines (default: derived from root command name)
+
+  ## Return value
+
+    * On success, returns whatever the matched command's `run/2` returns.
+    * On a usage failure (unknown option, missing required argument, bad choice,
+      unknown or ambiguous subcommand, missing required subcommand), prints the
+      error and returns `{:error, :usage}`.
+    * For `--help` / `--version` (and a bare command that just prints help),
+      returns `:ok`.
+
+  Use the `{:error, :usage}` result to set a nonzero exit code, or call
+  `main/3` to have Cheer halt with a conventional code for you.
   """
-  @spec run(module(), [String.t()], keyword()) :: term()
+  @spec run(module(), [String.t()], keyword()) :: term() | {:error, :usage}
   def run(root_command, argv, opts \\ []) do
     prog = Keyword.get(opts, :prog)
     Cheer.Router.dispatch(root_command, argv, prog: prog)
+  end
+
+  @doc """
+  Run as an escript entry point, halting the VM with a conventional exit code.
+
+  Dispatches `argv` like `run/3`, then halts the VM: `0` on success (including
+  `--help` and `--version`) and `2` on a usage failure. The command's own
+  `run/2` return value does not affect the exit code; a command that wants
+  custom codes should call `run/3` and halt itself.
+
+      def main(argv), do: Cheer.main(MyApp.CLI, argv, prog: "myapp")
+  """
+  # main/2 and main/3 always System.halt, so they never return locally. That is
+  # the intended behaviour for an escript entry point, not a defect.
+  @dialyzer {:nowarn_function, [main: 2, main: 3]}
+  @spec main(module(), [String.t()], keyword()) :: no_return()
+  def main(root_command, argv, opts \\ []) do
+    case run(root_command, argv, opts) do
+      {:error, :usage} -> System.halt(2)
+      _ -> System.halt(0)
+    end
   end
 
   @doc """

--- a/lib/cheer/router.ex
+++ b/lib/cheer/router.ex
@@ -116,11 +116,11 @@ defmodule Cheer.Router do
 
       {:ambiguous, t, candidates} ->
         print_ambiguous_subcommand(t, candidates)
-        :ok
+        {:error, :usage}
 
       _ ->
         IO.puts("error: unknown command '#{token}'")
-        :ok
+        {:error, :usage}
     end
   end
 
@@ -136,17 +136,20 @@ defmodule Cheer.Router do
 
       {:ambiguous, token, candidates} ->
         print_ambiguous_subcommand(token, candidates)
+        {:error, :usage}
 
       {:error, _unknown_token} when external? ->
         run_leaf(command, meta, argv, opts, hooks)
 
       {:error, unknown_token} ->
         print_unknown_command(meta, unknown_token)
+        {:error, :usage}
 
       :none when meta.subcommands != [] and meta.subcommand_required ->
         IO.puts("error: a subcommand is required")
         IO.puts("")
         Cheer.Help.print(command, opts)
+        {:error, :usage}
 
       :none when meta.subcommands != [] and not external? ->
         Cheer.Help.print(command, opts)
@@ -172,7 +175,7 @@ defmodule Cheer.Router do
         apply_after_hooks(result, Map.get(meta, :after_run, []))
 
       :handled ->
-        :ok
+        {:error, :usage}
     end
   end
 

--- a/test/cheer_test.exs
+++ b/test/cheer_test.exs
@@ -628,6 +628,53 @@ defmodule CheerTest do
     end
   end
 
+  # -- Usage-failure return value (issue #49) ----------------------------------
+
+  describe "usage-failure return value (issue #49)" do
+    test "unknown option returns {:error, :usage}" do
+      capture_io(fn ->
+        assert {:error, :usage} = Cheer.run(TestGreet, ["world", "--bogus"])
+      end)
+    end
+
+    test "missing required argument returns {:error, :usage}" do
+      capture_io(fn ->
+        assert {:error, :usage} = Cheer.run(TestGreet, [])
+      end)
+    end
+
+    test "bad choice returns {:error, :usage}" do
+      capture_io(fn ->
+        assert {:error, :usage} =
+                 Cheer.run(TestValidation, ["--port", "8080", "--format", "yaml"])
+      end)
+    end
+
+    test "unknown subcommand returns {:error, :usage}" do
+      capture_io(fn ->
+        assert {:error, :usage} = Cheer.run(TestRoot, ["bogus"])
+      end)
+    end
+
+    test "missing required subcommand returns {:error, :usage}" do
+      capture_io(fn ->
+        assert {:error, :usage} = Cheer.run(CheerTest.TestSubRequired, [])
+      end)
+    end
+
+    test "success returns the command's own run/2 value" do
+      assert {:ok, %{name: "world"}} = Cheer.run(TestGreet, ["world"])
+    end
+
+    test "--help returns :ok" do
+      capture_io(fn -> assert :ok = Cheer.run(TestGreet, ["--help"]) end)
+    end
+
+    test "--version returns :ok" do
+      capture_io(fn -> assert :ok = Cheer.run(TestVersioned, ["--version"]) end)
+    end
+  end
+
   # -- Cross-param validation --------------------------------------------------
 
   defmodule TestCrossValidation do


### PR DESCRIPTION
Closes #49.

## Problem

`Cheer.run/3` returned `:ok` on every parse and validation failure, indistinguishable from a successful `--help`. An escript `main/1` could not tell a usage error from success, so `mycli --bogus; echo $?` returned `0`.

## Change

`Cheer.run/3` now returns `{:error, :usage}` on a usage failure:

- unknown option
- missing required argument
- bad choice / failed validation
- unknown or ambiguous subcommand
- missing required subcommand

Success still returns the matched command's own `run/2` value, and `--help` / `--version` still return `:ok`. The only behavior change is the error path, which previously collapsed to `:ok`.

## Cheer.main/3

Added an escript entry point that dispatches like `run/3` then halts the VM with a conventional code:

```elixir
def main(argv), do: Cheer.main(MyApp.CLI, argv, prog: "myapp")
# halts 0 on success (including --help / --version), 2 on usage failure
```

The command's own `run/2` value does not affect the exit code; a command wanting custom codes calls `run/3` and halts itself. `main/2` and `main/3` always halt, so a targeted `@dialyzer {:nowarn_function, ...}` documents the intentional no-local-return.

## Tests and docs

- `usage-failure return value` describe block: each failure class returns `{:error, :usage}`; success returns the raw `run/2` value; `--help` / `--version` return `:ok`. 220 passing (was 212).
- Documented the return contract on `Cheer.run/3`, added `Cheer.main/3`, and added an "Exit codes" section to the help/output guide.
- Credo and Dialyzer clean.