### PR TITLE
feat: args_conflicts_with_subcommands for optional subcommands

### DIFF
--- a/docs/guides/subcommands.md
+++ b/docs/guides/subcommands.md
@@ -123,6 +123,34 @@ Behavior:
 - `args[:external_subcommand]` is `nil` when no external sub was invoked,
   `{name, rest}` when one was. Pattern matches are total.
 
+## Optional subcommand (run the parent on an unknown token)
+
+By default a command that declares both `argument`s and `subcommand`s treats an
+unrecognized first token as an unknown command and errors. Set
+`args_conflicts_with_subcommands true` to make the subcommand optional: a token
+that does not match a declared subcommand is parsed as the parent's own
+positional, and option parsing continues across it.
+
+```elixir
+command "roba" do
+  args_conflicts_with_subcommands true
+
+  argument :prompt, type: :string, required: false
+  subcommand Roba.Commands.History
+end
+```
+
+Behavior:
+
+- `roba history` dispatches to the `history` subcommand (declared subs still
+  match first; with `infer_subcommands`, an unambiguous prefix matches too).
+- `roba "summarize this" --model haiku` runs the parent with
+  `prompt: "summarize this"` and `model: "haiku"`.
+- `roba` with no arguments runs the parent with the optional positional absent.
+
+Unlike `external_subcommands`, the parent parses normally, so its own options
+are recognized rather than passed through.
+
 ## Propagating version
 
 By default only the root's `-V` / `--version` prints its version. To share

--- a/lib/cheer/command.ex
+++ b/lib/cheer/command.ex
@@ -48,6 +48,11 @@ defmodule Cheer.Command do
       Module.register_attribute(__MODULE__, :cheer_propagate_version, accumulate: false)
       Module.register_attribute(__MODULE__, :cheer_infer_subcommands, accumulate: false)
       Module.register_attribute(__MODULE__, :cheer_external_subcommands, accumulate: false)
+
+      Module.register_attribute(__MODULE__, :cheer_args_conflicts_with_subcommands,
+        accumulate: false
+      )
+
       Module.register_attribute(__MODULE__, :cheer_display_order, accumulate: false)
       Module.register_attribute(__MODULE__, :cheer_trailing_var_arg, accumulate: false)
       Module.register_attribute(__MODULE__, :cheer_arguments, accumulate: true)

--- a/lib/cheer/command/compiler.ex
+++ b/lib/cheer/command/compiler.ex
@@ -20,6 +20,9 @@ defmodule Cheer.Command.Compiler do
     external_subcommands =
       Module.get_attribute(env.module, :cheer_external_subcommands) || false
 
+    args_conflicts_with_subcommands =
+      Module.get_attribute(env.module, :cheer_args_conflicts_with_subcommands) || false
+
     display_order = Module.get_attribute(env.module, :cheer_display_order)
     trailing_var_arg = Module.get_attribute(env.module, :cheer_trailing_var_arg)
     arguments = Module.get_attribute(env.module, :cheer_arguments) |> Enum.reverse()
@@ -114,6 +117,7 @@ defmodule Cheer.Command.Compiler do
           propagate_version: unquote(propagate_version),
           infer_subcommands: unquote(infer_subcommands),
           external_subcommands: unquote(external_subcommands),
+          args_conflicts_with_subcommands: unquote(args_conflicts_with_subcommands),
           display_order: unquote(display_order),
           trailing_var_arg: unquote(Macro.escape(trailing_var_arg)),
           arguments: unquote(arguments_expr),

--- a/lib/cheer/command/dsl.ex
+++ b/lib/cheer/command/dsl.ex
@@ -87,6 +87,32 @@ defmodule Cheer.Command.DSL do
     do: quote(do: @cheer_external_subcommands(unquote(val)))
 
   @doc """
+  Make subcommands optional so an unknown first token falls through to this
+  command's own positional arguments.
+
+  Without this, a command that declares both `argument`s and `subcommand`s
+  treats an unrecognized first token as an unknown command and errors. With it,
+  a token that does not match a declared subcommand is parsed as a positional
+  argument and option parsing continues across it, so the parent command runs.
+  Declared subcommands still take precedence: an exact (or, with
+  `infer_subcommands`, an unambiguous prefix) match dispatches to the
+  subcommand.
+
+      command "roba" do
+        args_conflicts_with_subcommands(true)
+
+        argument :prompt, type: :string, required: false
+        subcommand Roba.Commands.History
+      end
+
+  `roba history` dispatches to the subcommand, while `roba "summarize this"
+  --model haiku` runs the parent with `prompt: "summarize this"` and
+  `model: "haiku"`.
+  """
+  defmacro args_conflicts_with_subcommands(val),
+    do: quote(do: @cheer_args_conflicts_with_subcommands(unquote(val)))
+
+  @doc """
   Set this command's display order as a subcommand in its parent's help output.
 
   Lower numbers appear first. Commands without an explicit order fall back to

--- a/lib/cheer/router.ex
+++ b/lib/cheer/router.ex
@@ -127,6 +127,7 @@ defmodule Cheer.Router do
   defp dispatch_command(command, meta, argv, opts, hooks) do
     infer? = Map.get(meta, :infer_subcommands, false)
     external? = Map.get(meta, :external_subcommands, false)
+    args_conflict? = Map.get(meta, :args_conflicts_with_subcommands, false)
 
     case match_subcommand(meta.subcommands, argv, infer?) do
       {:ok, sub_module, rest} ->
@@ -141,6 +142,12 @@ defmodule Cheer.Router do
       {:error, _unknown_token} when external? ->
         run_leaf(command, meta, argv, opts, hooks)
 
+      # With args_conflicts_with_subcommands, an unknown first token is not an
+      # error: parse it (and the rest of argv) as this command's own arguments
+      # and options, so the parent command runs.
+      {:error, _unknown_token} when args_conflict? ->
+        run_leaf(command, meta, argv, opts, hooks)
+
       {:error, unknown_token} ->
         print_unknown_command(meta, unknown_token)
         {:error, :usage}
@@ -150,6 +157,11 @@ defmodule Cheer.Router do
         IO.puts("")
         Cheer.Help.print(command, opts)
         {:error, :usage}
+
+      # No subcommand matched (argv is empty or starts with an option). When the
+      # parent is runnable, dispatch to it rather than printing help.
+      :none when meta.subcommands != [] and args_conflict? ->
+        run_leaf(command, meta, argv, opts, hooks)
 
       :none when meta.subcommands != [] and not external? ->
         Cheer.Help.print(command, opts)

--- a/test/cheer_test.exs
+++ b/test/cheer_test.exs
@@ -675,6 +675,65 @@ defmodule CheerTest do
     end
   end
 
+  # -- args_conflicts_with_subcommands (issue #47) -----------------------------
+
+  defmodule TestRobaHistory do
+    use Cheer.Command
+
+    command "history" do
+      about("Show history")
+    end
+
+    @impl Cheer.Command
+    def run(_args, _raw), do: :history
+  end
+
+  defmodule TestRoba do
+    use Cheer.Command
+
+    command "roba" do
+      about("Roba root")
+      args_conflicts_with_subcommands(true)
+
+      argument(:prompt, type: :string, required: false, help: "Prompt")
+      option(:model, type: :string, help: "Model")
+
+      subcommand(CheerTest.TestRobaHistory)
+    end
+
+    @impl Cheer.Command
+    def run(args, _raw), do: {:ok, args}
+  end
+
+  describe "args_conflicts_with_subcommands (issue #47)" do
+    test "declared subcommand still dispatches" do
+      assert :history = Cheer.run(TestRoba, ["history"])
+    end
+
+    test "unknown first token falls through to the parent positional" do
+      assert {:ok, %{prompt: "summarize this"}} = Cheer.run(TestRoba, ["summarize this"])
+    end
+
+    test "options keep parsing across the positional" do
+      assert {:ok, %{prompt: "summarize this", model: "haiku"}} =
+               Cheer.run(TestRoba, ["summarize this", "--model", "haiku"])
+    end
+
+    test "leading options before the positional still run the parent" do
+      assert {:ok, %{prompt: "a prompt", model: "haiku"}} =
+               Cheer.run(TestRoba, ["--model", "haiku", "a prompt"])
+    end
+
+    test "bare command runs the parent with the optional positional absent" do
+      assert {:ok, args} = Cheer.run(TestRoba, [])
+      refute Map.has_key?(args, :prompt)
+    end
+
+    test "the flag is recorded in metadata" do
+      assert TestRoba.__cheer_meta__().args_conflicts_with_subcommands == true
+    end
+  end
+
   # -- Cross-param validation --------------------------------------------------
 
   defmodule TestCrossValidation do


### PR DESCRIPTION
Closes #47.

## Problem

A command that declared both `argument`s and `subcommand`s treated an unrecognized first token as an unknown command and errored:

```elixir
command "roba" do
  argument :prompt, type: :string, required: false
  subcommand Roba.Commands.History
end
```

- `roba history` dispatched correctly.
- `roba "summarize this"` failed with `error: unknown command 'summarize this'`.

The `external_subcommands` workaround parses with `OptionParser.parse_head`, which stops option parsing at the first positional, so `roba "a prompt" --model haiku` dropped `--model` and routed the positional to `:external_subcommand` instead of the declared `:prompt`.

## Change

Add a command-level flag:

```elixir
command "roba" do
  args_conflicts_with_subcommands true

  argument :prompt, type: :string, required: false
  subcommand Roba.Commands.History
end
```

When set, a first token that does not match a declared subcommand (or an argv that starts with an option, or an empty argv) is parsed as the parent's own arguments and options through the standard parse path. So:

- `roba history` still dispatches to the subcommand (declared subs match first).
- `roba "summarize this" --model haiku` runs the parent with `prompt: "summarize this"` and `model: "haiku"` (options keep parsing across the positional).
- `roba` with no args runs the parent with the optional positional absent.
- `subcommand_required` still errors when no subcommand is given.

Unlike `external_subcommands`, the parent parses normally, so its own options are recognized rather than passed through.

## Implementation

- New `args_conflicts_with_subcommands/1` DSL macro, registered attribute, and meta key.
- `dispatch_command` routes the `{:error, unknown_token}` and option-leading `:none` cases to `run_leaf` (standard parse) when the flag is set, instead of printing an unknown-command error or help.

## Tests and docs

`args_conflicts_with_subcommands` describe block: subcommand precedence, unknown-token fallthrough, options across the positional, leading options, bare command, and the metadata flag. 226 passing (was 220). Added an "Optional subcommand" section to the subcommands guide. Credo and Dialyzer clean.