### PR TITLE
docs: Mix task cookbook guide and example project

### DIFF
--- a/docs/cookbook/devtool.md
+++ b/docs/cookbook/devtool.md
@@ -209,3 +209,5 @@ mix run -e 'Devtool.CLI.main(["server", "--help"])'
 - Guides: [Subcommands](../guides/subcommands.md),
   [Lifecycle hooks](../guides/lifecycle_hooks.md),
   [Constraints](../guides/constraints.md).
+- Next cookbook: [Mix task](mix_task.md) -- drive a `mix` command with the same
+  command definition.

--- a/docs/cookbook/mix_task.md
+++ b/docs/cookbook/mix_task.md
@@ -1,0 +1,151 @@
+# Mix task: drive `mix` commands with Cheer
+
+Cheer is not only for escripts. The same command definition can power a Mix
+task, so `mix greet world --loud` parses, validates, and renders help exactly
+like a standalone CLI. No framework changes are needed.
+
+Full runnable project: [`examples/mix_task/`](https://github.com/joshrotenberg/cheer/tree/main/examples/mix_task).
+
+## The key idea
+
+A Mix task is a module named `Mix.Tasks.<Name>` that does `use Mix.Task` and
+implements `run/1`, receiving the raw argv list. A Cheer command does
+`use Cheer.Command` and implements `run/2`, receiving parsed args. These do not
+collide: `run/1` and `run/2` have different arities, so one module can be both.
+
+The Mix entry point (`run/1`) delegates to `Cheer.run/3`, which does the
+parsing, validation, and help rendering and then calls your `run/2`.
+
+## The task
+
+```elixir
+defmodule Mix.Tasks.Greet do
+  @shortdoc "Greet someone with style"
+
+  @moduledoc """
+  #{@shortdoc}
+
+  ## Examples
+
+      mix greet world
+      mix greet world --loud --times 3
+      GREET_GREETING=Hey mix greet Ada
+      mix greet --help
+  """
+
+  use Mix.Task
+  use Cheer.Command
+
+  command "greet" do
+    about "Greet someone with style"
+
+    argument :name, type: :string, required: true, help: "Who to greet"
+
+    option :greeting, type: :string, default: "Hello", env: "GREET_GREETING",
+      help: "Greeting word"
+
+    option :loud, type: :boolean, short: :l, help: "SHOUT the greeting"
+
+    option :times, type: :integer, short: :n, default: 1,
+      validate: fn n -> if n in 1..10, do: :ok, else: {:error, "times must be 1-10"} end,
+      help: "Repeat the greeting"
+  end
+
+  # Mix entry point. Delegate to Cheer, then translate a usage failure into the
+  # Mix exit idiom.
+  @impl Mix.Task
+  def run(argv) do
+    case Cheer.run(__MODULE__, argv, prog: "mix greet") do
+      {:error, :usage} -> exit({:shutdown, 2})
+      other -> other
+    end
+  end
+
+  # Cheer leaf handler. Runs once argv has parsed and validated cleanly.
+  @impl Cheer.Command
+  def run(%{name: name} = args, _raw) do
+    greeting = "#{args[:greeting]}, #{name}!"
+    greeting = if args[:loud], do: String.upcase(greeting), else: greeting
+
+    for _ <- 1..args[:times] do
+      IO.puts(greeting)
+    end
+
+    :ok
+  end
+end
+```
+
+## Run it
+
+```sh
+cd examples/mix_task
+mix deps.get
+
+mix greet world
+# Hello, world!
+
+mix greet world --loud --times 3
+# HELLO, WORLD!
+# HELLO, WORLD!
+# HELLO, WORLD!
+
+GREET_GREETING=Hey mix greet Ada
+# Hey, Ada!
+
+mix greet --help
+# Usage: mix greet <name> [OPTIONS]
+# ...
+
+mix greet
+# error: missing required argument(s): <name>
+# ... (exits 2)
+```
+
+`mix help` and `mix help greet` render from `@shortdoc` and `@moduledoc`, the
+standard Mix mechanism, so the task lists and documents itself like any other.
+
+## Signaling failure
+
+Return `{:error, :usage}` from a usage failure into a nonzero exit code with
+`exit({:shutdown, 2})`. That is the Mix idiom: Mix catches this exit and halts
+with the given code without a crash report.
+
+Do **not** use `Cheer.main/3` inside a Mix task. `main/3` calls `System.halt`,
+which hard-kills the VM immediately: it skips Mix's own cleanup and is wrong
+inside `mix`, CI, and umbrella projects. `Cheer.run/3` exists as the separate
+primitive precisely so callers can decide how to exit. `main/3` is for escript
+entry points, where halting the VM is the whole point.
+
+## Starting the application
+
+Mix does not start your application before running a task. If the task needs the
+app running (a repo, a supervision tree, config), start it inside `run/2`:
+
+```elixir
+@impl Cheer.Command
+def run(args, _raw) do
+  Mix.Task.run("app.start")
+  # ... now the app is running
+end
+```
+
+`Application.ensure_all_started/1` works too when you only need a specific
+application.
+
+## What it shows
+
+- **One module, two behaviours** -- `use Mix.Task` and `use Cheer.Command`
+  coexist because `run/1` and `run/2` do not collide.
+- **`prog: "mix greet"`** -- so the usage line reads as the Mix invocation, not
+  a bare command name.
+- **Exit codes** -- `exit({:shutdown, 2})` translates a Cheer usage failure into
+  a conventional nonzero exit.
+- **Mix help integration** -- `@shortdoc` / `@moduledoc` drive `mix help`.
+- **The `main/3` caveat** -- never `System.halt` from inside a Mix task.
+
+## See also
+
+- Cookbook: [Greeter](greeter.md) -- the same command as a standalone escript.
+- Guides: [Options](../guides/options.md), [Arguments](../guides/arguments.md),
+  [Validation](../guides/validation.md).

--- a/examples/mix_task/lib/mix/tasks/greet.ex
+++ b/examples/mix_task/lib/mix/tasks/greet.ex
@@ -1,0 +1,59 @@
+defmodule Mix.Tasks.Greet do
+  @shortdoc "Greet someone with style"
+
+  @moduledoc """
+  #{@shortdoc}
+
+  A single Cheer command driving a Mix task. Because `Mix.Task` needs `run/1`
+  and `Cheer.Command` needs `run/2`, one module can be both.
+
+  ## Examples
+
+      mix greet world
+      mix greet world --loud --times 3
+      GREET_GREETING=Hey mix greet Ada
+      mix greet --help
+  """
+
+  use Mix.Task
+  use Cheer.Command
+
+  command "greet" do
+    about "Greet someone with style"
+
+    argument :name, type: :string, required: true, help: "Who to greet"
+
+    option :greeting, type: :string, default: "Hello", env: "GREET_GREETING",
+      help: "Greeting word"
+
+    option :loud, type: :boolean, short: :l, help: "SHOUT the greeting"
+
+    option :times, type: :integer, short: :n, default: 1,
+      validate: fn n -> if n in 1..10, do: :ok, else: {:error, "times must be 1-10"} end,
+      help: "Repeat the greeting"
+  end
+
+  # Mix entry point. Delegate to Cheer and translate a usage failure into the
+  # Mix exit idiom. Do not use Cheer.main/3 here: it calls System.halt, which
+  # hard-kills the VM and skips Mix cleanup.
+  @impl Mix.Task
+  def run(argv) do
+    case Cheer.run(__MODULE__, argv, prog: "mix greet") do
+      {:error, :usage} -> exit({:shutdown, 2})
+      other -> other
+    end
+  end
+
+  # Cheer leaf handler. Runs once argv has parsed and validated cleanly.
+  @impl Cheer.Command
+  def run(%{name: name} = args, _raw) do
+    greeting = "#{args[:greeting]}, #{name}!"
+    greeting = if args[:loud], do: String.upcase(greeting), else: greeting
+
+    for _ <- 1..args[:times] do
+      IO.puts(greeting)
+    end
+
+    :ok
+  end
+end

--- a/examples/mix_task/mix.exs
+++ b/examples/mix_task/mix.exs
@@ -1,0 +1,18 @@
+defmodule GreetTask.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :greet_task,
+      version: "0.1.0",
+      elixir: "~> 1.15",
+      deps: deps()
+    ]
+  end
+
+  defp deps do
+    [
+      {:cheer, path: "../.."}
+    ]
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -80,6 +80,7 @@ defmodule Cheer.MixProject do
         "docs/guides/testing.md",
         "docs/cookbook/greeter.md",
         "docs/cookbook/devtool.md",
+        "docs/cookbook/mix_task.md",
         "CHANGELOG.md"
       ],
       groups_for_extras: [


### PR DESCRIPTION
Closes #56.

## Plan

Cheer already works for Mix tasks with no framework changes. This documents the pattern and ships a runnable example, mirroring the existing `greeter`/`devtool` cookbook + example pairs.

### Deliverables

- [ ] `docs/cookbook/mix_task.md` cookbook guide
- [ ] Register it in `mix.exs` `docs/0` (`extras` list and `Cookbook` group)
- [ ] `examples/mix_task/` runnable example project (`mix.exs` + `lib/mix/tasks/*.ex`)
- [ ] Cross-link from the `devtool` cookbook "See also" so the cookbook sequence chains

### What the guide covers

- One `Mix.Tasks.*` module doing `use Mix.Task` + `use Cheer.Command` (no arity collision: `run/1` for Mix, `run/2` for Cheer); `run/1` delegates to `Cheer.run/3`.
- `prog: "mix <task>"` for correct usage/help lines.
- Signaling failure via `exit({:shutdown, 2})` on `{:error, :usage}`, the Mix idiom.
- Warning against `Cheer.main/3` in a Mix task (calls `System.halt`, hard-kills the VM, skips Mix cleanup).
- `@shortdoc` / `@moduledoc` for `mix help` output.
- Starting the app from `run/2` when needed (`Mix.Task.run("app.start")`).

### Verification

- Compile the example and run the task in happy-path, `--help`, missing-arg (exit 2), and bad-flag (exit 2) modes.
- `mix docs` builds with the new extra.

Follow-up: #55 (`Cheer.MixTask` helper) builds on this and will update the guide to show the helper as the primary path.