### PR TITLE
feat(router): suggest closest option name for unknown flags

### DIFF
--- a/lib/cheer/router.ex
+++ b/lib/cheer/router.ex
@@ -240,7 +240,7 @@ defmodule Cheer.Router do
       OptionParser.parse(argv, strict: option_parser_opts, aliases: option_aliases)
 
     if invalid != [] do
-      print_invalid_options_error(command, invalid, opts)
+      print_invalid_options_error(command, invalid, opts, all_options)
       :handled
     else
       args = apply_defaults(all_options)
@@ -321,7 +321,7 @@ defmodule Cheer.Router do
       OptionParser.parse_head(argv, strict: option_parser_opts, aliases: option_aliases)
 
     if invalid != [] do
-      print_invalid_options_error(command, invalid, opts)
+      print_invalid_options_error(command, invalid, opts, all_options)
       :handled
     else
       args = apply_defaults(all_options)
@@ -936,10 +936,29 @@ defmodule Cheer.Router do
     Cheer.Help.print(command, opts)
   end
 
-  defp print_invalid_options_error(command, invalid, opts) do
+  defp print_invalid_options_error(command, invalid, opts, all_options) do
     flags = Enum.map_join(invalid, ", ", fn {flag, _} -> flag end)
     IO.puts("error: unknown option(s): #{flags}")
+
+    candidates = option_name_candidates(all_options)
+
+    for {flag, _value} <- invalid do
+      with "--" <> name <- flag,
+           suggestion when not is_nil(suggestion) <- suggest(name, candidates) do
+        IO.puts("\n  Did you mean '--#{suggestion}'?")
+      else
+        _ -> :ok
+      end
+    end
+
     IO.puts("")
     Cheer.Help.print(command, opts)
+  end
+
+  defp option_name_candidates(all_options) do
+    Enum.flat_map(all_options, fn {name, opts} ->
+      aliases = Keyword.get(opts, :aliases, [])
+      [flag_string(name) | Enum.map(aliases, &flag_string/1)]
+    end)
   end
 end

--- a/test/cheer_test.exs
+++ b/test/cheer_test.exs
@@ -416,6 +416,35 @@ defmodule CheerTest do
 
       assert output =~ "error: unknown option(s)"
     end
+
+    test "suggests the closest declared option name for a typo'd flag" do
+      output =
+        capture_io(fn ->
+          Cheer.run(CheerTest.TestOptAliases, ["--colr", "red"])
+        end)
+
+      assert output =~ "error: unknown option(s): --colr"
+      assert output =~ "Did you mean '--color'?"
+    end
+
+    test "suggests an alias when it's the closest match" do
+      output =
+        capture_io(fn ->
+          Cheer.run(CheerTest.TestOptAliases, ["--colour-", "red"])
+        end)
+
+      assert output =~ "Did you mean '--colour'?"
+    end
+
+    test "prints no suggestion when nothing is close enough" do
+      output =
+        capture_io(fn ->
+          Cheer.run(CheerTest.TestOptAliases, ["--zzzzzzzz", "red"])
+        end)
+
+      assert output =~ "error: unknown option(s): --zzzzzzzz"
+      refute output =~ "Did you mean"
+    end
   end
 
   # -- Environment variable fallback -------------------------------------------


### PR DESCRIPTION
## Problem

Cheer already prints `"Did you mean 'x'?"` for unknown subcommands (`suggest/2` in `lib/cheer/router.ex:921`), but `print_invalid_options_error` (`router.ex:939`) printed no suggestion for an unknown flag.

## Fix

Wired the existing `suggest/2` into the invalid-options path. For each unmatched `--flag`, it's compared (via the existing Jaro-distance `suggest/2`) against the command's declared option long-names and their aliases, both kebab-cased via the existing `flag_string/1` helper. Both call sites (`parse_standard` and `parse_with_external_subcommand`) already had `all_options` in scope, so no new option-collection logic was needed.

## Tests

Reused the existing `TestOptAliases` command (`option(:color, aliases: [:colour])`):
- `--colr` → suggests `--color`
- `--colour-` → suggests the alias `--colour`
- `--zzzzzzzz` (nothing close) → no suggestion printed

`mix test` → 229/229 passed. `mix format --check-formatted` clean. (Note: `mix credo --strict` currently crashes on this repo's `test/cheer_test.exs` on a pre-existing regex sigil at line ~1931/1961, independent of this change — reproduces identically on a clean `main` checkout.)

Closes #71