### PR TITLE
fix: repeated lifecycle hooks and validators silently drop all but the first

### DIFF
--- a/lib/cheer/command.ex
+++ b/lib/cheer/command.ex
@@ -61,11 +61,11 @@ defmodule Cheer.Command do
       Module.register_attribute(__MODULE__, :cheer_has_validate, accumulate: true)
       Module.register_attribute(__MODULE__, :cheer_groups, accumulate: true)
 
-      # Counters for indexed function generation
-      Module.put_attribute(__MODULE__, :cheer_validator_count, 0)
-      Module.put_attribute(__MODULE__, :cheer_before_run_count, 0)
-      Module.put_attribute(__MODULE__, :cheer_after_run_count, 0)
-      Module.put_attribute(__MODULE__, :cheer_persistent_before_run_count, 0)
+      # Counters for indexed function generation are managed at macro-expansion
+      # time by Cheer.Command.DSL.next_hook_index/2, which lazily starts from 0.
+      # They must not be initialized here: __using__ runs during body execution,
+      # after macros expand, so setting them now would reset the expansion-time
+      # count back to 0 and drop every generated hook clause.
 
       # Current group context (set by `group` macro)
       Module.put_attribute(__MODULE__, :cheer_current_group, nil)

--- a/lib/cheer/command/compiler.ex
+++ b/lib/cheer/command/compiler.ex
@@ -29,10 +29,16 @@ defmodule Cheer.Command.Compiler do
     options = Module.get_attribute(env.module, :cheer_options) |> Enum.reverse()
     subcommands = Module.get_attribute(env.module, :cheer_subcommands) |> Enum.reverse()
     has_validate = Module.get_attribute(env.module, :cheer_has_validate)
-    validator_count = Module.get_attribute(env.module, :cheer_validator_count)
-    before_run_count = Module.get_attribute(env.module, :cheer_before_run_count)
-    after_run_count = Module.get_attribute(env.module, :cheer_after_run_count)
-    persistent_before_count = Module.get_attribute(env.module, :cheer_persistent_before_run_count)
+    # Hook counters are incremented at macro-expansion time (see
+    # Cheer.Command.DSL.next_hook_index/2). A command that declares no hooks of a
+    # kind never writes the attribute, so default nil to 0.
+    validator_count = Module.get_attribute(env.module, :cheer_validator_count) || 0
+    before_run_count = Module.get_attribute(env.module, :cheer_before_run_count) || 0
+    after_run_count = Module.get_attribute(env.module, :cheer_after_run_count) || 0
+
+    persistent_before_count =
+      Module.get_attribute(env.module, :cheer_persistent_before_run_count) || 0
+
     raw_groups = Module.get_attribute(env.module, :cheer_groups) |> Enum.reverse()
 
     # Validate: leaf commands (no subcommands) must define run/2

--- a/lib/cheer/command/dsl.ex
+++ b/lib/cheer/command/dsl.ex
@@ -240,11 +240,10 @@ defmodule Cheer.Command.DSL do
 
   @doc "Cross-parameter validation function. Receives args map, returns `:ok` or `{:error, msg}`."
   defmacro validate(fun) do
-    quote do
-      count = Module.get_attribute(__MODULE__, :cheer_validator_count)
-      Module.put_attribute(__MODULE__, :cheer_validator_count, count + 1)
+    count = next_hook_index(__CALLER__.module, :cheer_validator_count)
 
-      def __cheer_cross_validate__(unquote(Macro.var(:count, __MODULE__)), args) do
+    quote do
+      def __cheer_cross_validate__(unquote(count), args) do
         unquote(fun).(args)
       end
     end
@@ -254,11 +253,10 @@ defmodule Cheer.Command.DSL do
 
   @doc "Run a function on args before `run/2`. Receives and returns args map."
   defmacro before_run(fun) do
-    quote do
-      count = Module.get_attribute(__MODULE__, :cheer_before_run_count)
-      Module.put_attribute(__MODULE__, :cheer_before_run_count, count + 1)
+    count = next_hook_index(__CALLER__.module, :cheer_before_run_count)
 
-      def __cheer_before_run__(unquote(Macro.var(:count, __MODULE__)), args) do
+    quote do
+      def __cheer_before_run__(unquote(count), args) do
         unquote(fun).(args)
       end
     end
@@ -266,11 +264,10 @@ defmodule Cheer.Command.DSL do
 
   @doc "Run a function on the result after `run/2`. Receives and returns result."
   defmacro after_run(fun) do
-    quote do
-      count = Module.get_attribute(__MODULE__, :cheer_after_run_count)
-      Module.put_attribute(__MODULE__, :cheer_after_run_count, count + 1)
+    count = next_hook_index(__CALLER__.module, :cheer_after_run_count)
 
-      def __cheer_after_run__(unquote(Macro.var(:count, __MODULE__)), result) do
+    quote do
+      def __cheer_after_run__(unquote(count), result) do
         unquote(fun).(result)
       end
     end
@@ -278,14 +275,24 @@ defmodule Cheer.Command.DSL do
 
   @doc "Like `before_run`, but inherited by all child subcommands."
   defmacro persistent_before_run(fun) do
-    quote do
-      count = Module.get_attribute(__MODULE__, :cheer_persistent_before_run_count)
-      Module.put_attribute(__MODULE__, :cheer_persistent_before_run_count, count + 1)
+    count = next_hook_index(__CALLER__.module, :cheer_persistent_before_run_count)
 
-      def __cheer_persistent_before_run__(unquote(Macro.var(:count, __MODULE__)), args) do
+    quote do
+      def __cheer_persistent_before_run__(unquote(count), args) do
         unquote(fun).(args)
       end
     end
+  end
+
+  # Read and increment a per-kind hook counter at macro-expansion time so each
+  # generated clause head carries a distinct integer literal (e.g. `(0, args)`,
+  # `(1, args)`). Using the counter's value here rather than `Macro.var(:count)`
+  # is what keeps later clauses from being shadowed by clause 0. Because macros
+  # expand in source order, the returned index matches declaration order.
+  defp next_hook_index(module, attr) do
+    count = Module.get_attribute(module, attr) || 0
+    Module.put_attribute(module, attr, count + 1)
+    count
   end
 
   # -- Param groups --

--- a/test/cheer_test.exs
+++ b/test/cheer_test.exs
@@ -865,6 +865,76 @@ defmodule CheerTest do
     end
   end
 
+  # -- Repeated hooks and validators (#58) -------------------------------------
+
+  defmodule TestMultiHooks do
+    use Cheer.Command
+
+    command "multi" do
+      about("multiple hooks of each kind")
+
+      before_run(fn a -> Map.update(a, :trace, ["b0"], &(&1 ++ ["b0"])) end)
+      before_run(fn a -> Map.update(a, :trace, ["b1"], &(&1 ++ ["b1"])) end)
+      before_run(fn a -> Map.update(a, :trace, ["b2"], &(&1 ++ ["b2"])) end)
+
+      after_run(fn r -> r ++ ["a0"] end)
+      after_run(fn r -> r ++ ["a1"] end)
+    end
+
+    @impl Cheer.Command
+    def run(args, _raw), do: Map.get(args, :trace, [])
+  end
+
+  defmodule TestMultiValidators do
+    use Cheer.Command
+
+    command "mv" do
+      option(:a, type: :integer)
+      option(:b, type: :integer)
+
+      validate(fn args -> if args[:a], do: :ok, else: {:error, "a required"} end)
+      validate(fn args -> if args[:b], do: :ok, else: {:error, "b required"} end)
+    end
+
+    @impl Cheer.Command
+    def run(args, _raw), do: {:ok, args}
+  end
+
+  defmodule TestMultiPersistParent do
+    use Cheer.Command
+
+    command "mpp" do
+      persistent_before_run(fn a -> Map.put(a, :p0, true) end)
+      persistent_before_run(fn a -> Map.put(a, :p1, true) end)
+
+      subcommand(CheerTest.TestHooksChild)
+    end
+  end
+
+  describe "repeated lifecycle hooks and validators (#58)" do
+    test "all before_run and after_run hooks run in declaration order" do
+      assert Cheer.run(TestMultiHooks, []) == ["b0", "b1", "b2", "a0", "a1"]
+    end
+
+    test "every cross-param validator is enforced, not just the first" do
+      out =
+        capture_io(fn ->
+          assert Cheer.run(TestMultiValidators, ["--a", "1"]) == {:error, :usage}
+        end)
+
+      assert out =~ "b required"
+
+      out2 = capture_io(fn -> assert Cheer.run(TestMultiValidators, []) == {:error, :usage} end)
+      assert out2 =~ "a required"
+
+      assert {:ok, _} = Cheer.run(TestMultiValidators, ["--a", "1", "--b", "2"])
+    end
+
+    test "all persistent_before_run hooks propagate to children" do
+      assert {:ok, %{p0: true, p1: true}} = Cheer.run(TestMultiPersistParent, ["child"])
+    end
+  end
+
   # -- Mutually exclusive / co-occurring groups --------------------------------
 
   defmodule TestGroups do


### PR DESCRIPTION
Closes #58.

## Problem

When a command declares 2+ `before_run`, `after_run`, `validate`, or `persistent_before_run` of the same kind, only the first runs; the rest are silently dropped, and the compiler prints "redundant clause" warnings.

Verified before fix:
```
before_run a:1, b:2, c:3  =>  Cheer.run(cmd, [])  =>  %{a: 1}   # b, c dropped
```

## Root cause

`lib/cheer/command/dsl.ex` generated the indexed accessor clause head with `unquote(Macro.var(:count, __MODULE__))`, which injects a *binding variable* (matches any first arg) rather than the counter's integer value. So every clause has the identical head `def __cheer_before_run__(count, args)` and clause 0 shadows the rest.

## Fix

Read and increment the per-kind counter at macro-expansion time (via `__CALLER__.module`) and emit the integer **literal** into each clause head (`def __cheer_before_run__(0, args)`, `(1, args)`, ...). The compiler's `make_indexed_fns/2` contract (dispatch by `apply(__MODULE__, fname, [idx, val])`) is unchanged.

## Plan

- [ ] Add an expansion-time `next_hook_index/2` helper.
- [ ] Convert `validate`, `before_run`, `after_run`, `persistent_before_run` to emit literal indices.
- [ ] Tests: 2+ hooks of each kind run in order; multiple cross-param validators all run.
- [ ] Confirm no "redundant clause" warnings remain.

Release blocker for 0.1.6.