### PR TITLE
feat: implement command-level hide (fixes documented-but-missing setting)

### DIFF
--- a/docs/guides/help_and_output.md
+++ b/docs/guides/help_and_output.md
@@ -79,14 +79,25 @@ predictable.
 
 ## Hiding from help
 
+Hide an individual option or argument with `hide: true`:
+
 ```elixir
 option :internal, type: :boolean, hide: true
+argument :legacy, type: :string, hide: true
+```
+
+Hide a whole subcommand with the command-level `hide` setting:
+
+```elixir
 command "debug" do
+  about "Internal diagnostics"
   hide true
 end
 ```
 
-Still accepted by the parser; absent from help output.
+Hidden items are still accepted by the parser and a hidden subcommand is still
+dispatchable; they are only omitted from help output, shell completion, and the
+"Available commands" list shown on an unknown-command error.
 
 ## Flag naming
 

--- a/lib/cheer.ex
+++ b/lib/cheer.ex
@@ -97,7 +97,10 @@ defmodule Cheer do
       arguments: Enum.map(meta.arguments, fn {name, opts} -> {name, opts} end),
       options: Enum.map(meta.options, fn {name, opts} -> {name, opts} end),
       groups: Map.get(meta, :groups, %{}),
-      subcommands: Enum.map(meta.subcommands, &tree/1)
+      subcommands:
+        meta.subcommands
+        |> Enum.reject(fn sub -> Map.get(sub.__cheer_meta__(), :hide, false) end)
+        |> Enum.map(&tree/1)
     }
   end
 end

--- a/lib/cheer/command.ex
+++ b/lib/cheer/command.ex
@@ -44,6 +44,7 @@ defmodule Cheer.Command do
       Module.register_attribute(__MODULE__, :cheer_after_help, accumulate: false)
       Module.register_attribute(__MODULE__, :cheer_aliases, accumulate: false)
       Module.register_attribute(__MODULE__, :cheer_usage, accumulate: false)
+      Module.register_attribute(__MODULE__, :cheer_hide, accumulate: false)
       Module.register_attribute(__MODULE__, :cheer_subcommand_required, accumulate: false)
       Module.register_attribute(__MODULE__, :cheer_propagate_version, accumulate: false)
       Module.register_attribute(__MODULE__, :cheer_infer_subcommands, accumulate: false)

--- a/lib/cheer/command/compiler.ex
+++ b/lib/cheer/command/compiler.ex
@@ -13,6 +13,7 @@ defmodule Cheer.Command.Compiler do
     after_help = Module.get_attribute(env.module, :cheer_after_help)
     aliases = Module.get_attribute(env.module, :cheer_aliases) || []
     usage = Module.get_attribute(env.module, :cheer_usage)
+    hide = Module.get_attribute(env.module, :cheer_hide) || false
     subcommand_required = Module.get_attribute(env.module, :cheer_subcommand_required) || false
     propagate_version = Module.get_attribute(env.module, :cheer_propagate_version) || false
     infer_subcommands = Module.get_attribute(env.module, :cheer_infer_subcommands) || false
@@ -119,6 +120,7 @@ defmodule Cheer.Command.Compiler do
           after_help: unquote(after_help),
           aliases: unquote(aliases),
           usage: unquote(usage),
+          hide: unquote(hide),
           subcommand_required: unquote(subcommand_required),
           propagate_version: unquote(propagate_version),
           infer_subcommands: unquote(infer_subcommands),

--- a/lib/cheer/command/dsl.ex
+++ b/lib/cheer/command/dsl.ex
@@ -42,6 +42,18 @@ defmodule Cheer.Command.DSL do
   @doc "Override the auto-generated usage line in help output."
   defmacro usage(text), do: quote(do: @cheer_usage(unquote(text)))
 
+  @doc """
+  Hide this command from its parent's help, shell completion, and unknown-command
+  listings. The command stays fully dispatchable; only its visibility is affected.
+
+  Useful for internal, experimental, or legacy commands.
+
+      command "debug" do
+        hide true
+      end
+  """
+  defmacro hide(val \\ true), do: quote(do: @cheer_hide(unquote(val)))
+
   @doc "Require that a subcommand is provided (error instead of showing help)."
   defmacro subcommand_required(val), do: quote(do: @cheer_subcommand_required(unquote(val)))
 

--- a/lib/cheer/router.ex
+++ b/lib/cheer/router.ex
@@ -912,10 +912,17 @@ defmodule Cheer.Router do
   defp print_unknown_command(meta, token) do
     IO.puts("error: unknown command '#{token}'")
 
+    # Hidden commands stay dispatchable but are not advertised in suggestions or
+    # the available-commands list.
+    visible =
+      Enum.reject(meta.subcommands, fn sub ->
+        Map.get(sub.__cheer_meta__(), :hide, false)
+      end)
+
     # "Did you mean?" suggestion
-    if meta.subcommands != [] do
+    if visible != [] do
       names =
-        Enum.flat_map(meta.subcommands, fn sub ->
+        Enum.flat_map(visible, fn sub ->
           sub_meta = sub.__cheer_meta__()
           [sub_meta.name | Map.get(sub_meta, :aliases, [])]
         end)
@@ -927,7 +934,7 @@ defmodule Cheer.Router do
 
       IO.puts("\nAvailable commands:")
 
-      for sub <- meta.subcommands do
+      for sub <- visible do
         sub_meta = sub.__cheer_meta__()
         IO.puts("  #{sub_meta.name}")
       end

--- a/test/cheer_test.exs
+++ b/test/cheer_test.exs
@@ -1365,6 +1365,66 @@ defmodule CheerTest do
     end
   end
 
+  defmodule TestHiddenSub do
+    use Cheer.Command
+
+    command "debug" do
+      about("Internal diagnostics")
+      hide()
+    end
+
+    @impl Cheer.Command
+    def run(_args, _raw), do: :debug_ran
+  end
+
+  defmodule TestVisibleSub do
+    use Cheer.Command
+
+    command "show" do
+      about("Visible command")
+    end
+
+    @impl Cheer.Command
+    def run(_args, _raw), do: :show_ran
+  end
+
+  defmodule TestHiddenCmdRoot do
+    use Cheer.Command
+
+    command "app" do
+      about("Root with a hidden subcommand")
+      subcommand(TestHiddenSub)
+      subcommand(TestVisibleSub)
+    end
+  end
+
+  describe "hidden subcommands (#60)" do
+    test "hidden subcommand is absent from parent help but visible ones remain" do
+      output = capture_io(fn -> Cheer.run(TestHiddenCmdRoot, ["--help"]) end)
+      refute output =~ "debug"
+      assert output =~ "show"
+    end
+
+    test "hidden subcommand is still dispatchable" do
+      assert Cheer.run(TestHiddenCmdRoot, ["debug"]) == :debug_ran
+    end
+
+    test "hidden subcommand is excluded from Cheer.tree/1" do
+      names = Enum.map(Cheer.tree(TestHiddenCmdRoot).subcommands, & &1.name)
+      assert names == ["show"]
+    end
+
+    test "hidden subcommand is absent from the unknown-command listing" do
+      output = capture_io(fn -> Cheer.run(TestHiddenCmdRoot, ["nope"]) end)
+      assert output =~ "Available commands:"
+      refute output =~ "debug"
+    end
+
+    test "hide defaults to true when called without an argument" do
+      assert TestHiddenSub.__cheer_meta__().hide == true
+    end
+  end
+
   # -- Subcommand aliases (#12) ------------------------------------------------
 
   defmodule TestAliasedSub do


### PR DESCRIPTION
Closes #60.

## Problem

`docs/guides/help_and_output.md` documents a command-level `hide true`, but no `hide` macro exists, so copying the snippet fails to compile. Meanwhile `lib/cheer/help.ex:53` already reads `sub_meta.hide` when rendering the subcommand list, so the display side is wired but the value can never be set (dead code, always false).

## Fix

Implement the setting so the read side comes alive:

- Add a `hide` command-level DSL macro (`hide true`, or bare `hide`).
- Register the `:cheer_hide` attribute and surface `hide` in `__cheer_meta__`.
- Filter hidden subcommands from `Cheer.tree/1`, so shell completions (built off the tree) omit them too.
- Exclude hidden subcommands from the "Available commands" list and typo suggestions on an unknown-command error.

A hidden command stays fully dispatchable; it is only omitted from help, completion, and error listings.

Note: hidden *option* filtering in `tree/1` is tracked separately in #68.

## Plan

- [ ] `hide` macro + `:cheer_hide` attribute + compiler meta passthrough
- [ ] `tree/1` and unknown-command listing filter hidden subcommands
- [ ] Fix/expand the `help_and_output.md` example
- [ ] Tests: hidden sub absent from parent help/tree, still dispatchable