### PR TITLE
docs: document long help and REPL commands

### DIFF
--- a/docs/guides/arguments.md
+++ b/docs/guides/arguments.md
@@ -83,6 +83,23 @@ argument :internal, type: :string, hide: true
 
 Accepted by the parser; omitted from help output.
 
+## Short vs long help
+
+Arguments can define both `:help` and `:long_help`. Short help (`-h`) uses
+`:help`; long help (`--help`) prefers `:long_help` when it is set.
+
+```elixir
+argument :path,
+  type: :string,
+  required: true,
+  value_name: "PATH",
+  help: "Input path",
+  long_help: "Input file or directory to process. Relative paths are resolved from the current working directory."
+```
+
+Use this when the concise description is enough for normal help, but the long
+form should explain defaults, accepted formats, or important side effects.
+
 ## See also
 
 - [Options](options.md) -- non-positional flags.

--- a/docs/guides/help_and_output.md
+++ b/docs/guides/help_and_output.md
@@ -9,7 +9,8 @@ Every command gets two help forms:
 
 - `-h` prints short help, built from `about` and `help` fields.
 - `--help` prints long help, preferring `long_about` over `about` and
-  `long_help` over `help` where those are set.
+  `long_help` over `help` where those are set. `long_help` is supported by
+  both options and positional arguments.
 
 ```elixir
 command "deploy" do
@@ -23,6 +24,10 @@ end
 option :env, type: :string,
   help: "Target environment",
   long_help: "Target environment (one of: dev, staging, prod)"
+
+argument :target, type: :string,
+  help: "Deployment target",
+  long_help: "Deployment target name, such as a service, cluster, or host group."
 ```
 
 ## Before and after help

--- a/docs/guides/repl.md
+++ b/docs/guides/repl.md
@@ -20,10 +20,21 @@ my-app> help
 my-app> exit
 ```
 
+Pass `:banner` to replace the default startup text:
+
+```elixir
+Cheer.Repl.start(MyApp.CLI.Root,
+  prog: "my-app",
+  banner: "MyApp admin shell\nType help, commands, or exit."
+)
+```
+
 ## Built-in commands
 
 - `help` / `?` -- print help for the root command (or a sub, with
   `help <sub>`).
+- `commands` -- print the command tree so you can inspect available
+  subcommands without leaving the REPL.
 - `exit` / `quit` / `Ctrl+D` -- leave the REPL.
 
 ## Tokenization


### PR DESCRIPTION
Closes #63.

## Summary

- Document argument-level `:long_help` in the arguments guide.
- Clarify that long help applies to both options and positional arguments.
- Document the REPL `commands` built-in and `:banner` start option.

## Verification

- `git diff --check`

I could not run `mix test` locally because `mix` is not installed in this environment.