### PR TITLE
docs: refresh guides and README for shipped features

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,14 @@ Cheer.run(MyApp.CLI.Greet, ["world", "--loud"], prog: "greet")
 
 - Declarative macro DSL for commands, options, arguments, and subcommands
 - Typed options and arguments with automatic coercion
+- Repeated (`:multi`) and multi-value (`:num_args`) options
 - Per-param and cross-param validation, choices, conditional-required
 - Per-option relations (`:conflicts_with`, `:requires`) and param groups
 - Env var fallback, defaults, boolean negation (`--no-*`)
 - Auto-generated help with headings, display order, before/after text
 - Subcommand prefix inference and `"Did you mean?"` suggestions
-- External subcommands for git-style plugin dispatchers
+- Optional subcommands (`:args_conflicts_with_subcommands`) and external
+  subcommands for git-style plugin dispatchers
 - Shell completion for bash, zsh, fish, and PowerShell
 - REPL mode driven by the same command tree
 - In-process test runner with output capture
@@ -76,7 +78,8 @@ Full docs on [hexdocs.pm/cheer](https://hexdocs.pm/cheer):
   [Testing](https://hexdocs.pm/cheer/testing.html).
 - **Cookbook:**
   [Greeter](https://hexdocs.pm/cheer/greeter.html) (single command),
-  [Devtool](https://hexdocs.pm/cheer/devtool.html) (nested subcommands with hooks and groups).
+  [Devtool](https://hexdocs.pm/cheer/devtool.html) (nested subcommands with hooks and groups),
+  [Mix task](https://hexdocs.pm/cheer/mix_task.html) (drive a `mix` task with a command).
 
 ## Runnable examples
 
@@ -86,6 +89,8 @@ Standalone Mix projects that match the cookbook entries live under
 - [`examples/greeter/`](examples/greeter/) -- minimal single-command CLI.
 - [`examples/devtool/`](examples/devtool/) -- nested multi-command CLI
   with lifecycle hooks and groups.
+- [`examples/mix_task/`](examples/mix_task/) -- a Cheer command driving a
+  `mix` task.
 
 ```sh
 cd examples/greeter && mix deps.get

--- a/docs/guides/arguments.md
+++ b/docs/guides/arguments.md
@@ -75,6 +75,17 @@ argument :port, type: :integer,
 
 See [Validation](validation.md) for more.
 
+## Extended help (`:long_help`)
+
+Like options, an argument can carry a longer description shown by `--help` (the
+long form) while `:help` is used in the short `-h` output:
+
+```elixir
+argument :path, type: :string,
+  help: "File to process",
+  long_help: "Path to the input file. Relative paths resolve against the current directory."
+```
+
 ## Hidden arguments
 
 ```elixir

--- a/docs/guides/options.md
+++ b/docs/guides/options.md
@@ -48,8 +48,30 @@ option :tag, type: :string, multi: true
 # --tag a --tag b  ->  args[:tag] == ["a", "b"]
 ```
 
-Distinct from multi-value (consuming multiple tokens after one flag), which
-is tracked as a future feature.
+## Multi-value flags (`:num_args`)
+
+`:num_args` collects several values from a single flag invocation into a list.
+Pass an integer for an exact count or a range for a variable count:
+
+```elixir
+option :point, type: :integer, num_args: 2
+# --point 1 2   ->  args[:point] == [1, 2]
+
+option :tags, type: :string, num_args: 1..3
+# --tags a b c  ->  args[:tags] == ["a", "b", "c"]
+```
+
+Both the space-separated form (`--point 1 2`) and the `--flag=value` form work.
+Collection stops at the next flag (a token starting with `-`) or at `--`, and
+each value is coerced to the option's `:type`. A count outside the declared
+range is a usage error:
+
+```
+--point 1   ->   error: --point expects 2 value(s), got 1
+```
+
+This is distinct from `:multi`, which repeats the whole flag (`--tag a --tag b`)
+rather than consuming multiple tokens after one flag.
 
 ## Aliases (long-form)
 

--- a/docs/guides/repl.md
+++ b/docs/guides/repl.md
@@ -9,6 +9,12 @@ same handlers.
 Cheer.Repl.start(MyApp.CLI.Root, prog: "my-app")
 ```
 
+Pass `:banner` to override the auto-generated greeting printed on start:
+
+```elixir
+Cheer.Repl.start(MyApp.CLI.Root, prog: "my-app", banner: "Welcome. Type 'help'.")
+```
+
 ```
 my-app> greet world --loud
 HELLO, WORLD!
@@ -24,6 +30,7 @@ my-app> exit
 
 - `help` / `?` -- print help for the root command (or a sub, with
   `help <sub>`).
+- `commands` -- print the full command tree (every subcommand, indented).
 - `exit` / `quit` / `Ctrl+D` -- leave the REPL.
 
 ## Tokenization


### PR DESCRIPTION
Closes #61. Closes #62. Closes #63.

Documentation-only refresh clearing the remaining P2 doc defects from the audit. No code changes.

## Changes

- **options.md** (#61): add a `:num_args` multi-value-flags section (exact int and range forms, `--flag=value`, coercion, out-of-range error) and remove the stale sentence that called it "a future feature."
- **arguments.md** (#63): document argument-level `:long_help`.
- **repl.md** (#63): document the `commands` built-in (verified at `lib/cheer/repl.ex:57`) and the `:banner` start option (`repl.ex:18,24`).
- **README** (#62): add `num_args` and `args_conflicts_with_subcommands` to the Features list (both merged to main), and add the Mix task cookbook and `examples/mix_task/` to the docs and examples lists.

`mix docs` builds clean.