### PR TITLE
fix(router): coerce :count env var fallback to integer

### DIFF
--- a/lib/cheer/router.ex
+++ b/lib/cheer/router.ex
@@ -574,6 +574,14 @@ defmodule Cheer.Router do
   end
 
   defp coerce_env(value, :boolean), do: value in ["true", "1", "yes"]
+
+  defp coerce_env(value, :count) do
+    case Integer.parse(value) do
+      {n, ""} -> n
+      _ -> value
+    end
+  end
+
   defp coerce_env(value, _), do: value
 
   # -- Per-param validation --

--- a/test/cheer_test.exs
+++ b/test/cheer_test.exs
@@ -471,6 +471,43 @@ defmodule CheerTest do
     end
   end
 
+  defmodule TestEnvVarCount do
+    use Cheer.Command
+
+    command "verbose" do
+      about("Verbose level from env")
+
+      option(:verbosity, type: :count, short: :v, default: 0, env: "TEST_CLAP_VERBOSITY")
+    end
+
+    @impl Cheer.Command
+    def run(args, _raw), do: {:ok, args}
+  end
+
+  describe "environment variable fallback for :count options" do
+    test "coerces a numeric env var to an integer, not a raw string" do
+      System.put_env("TEST_CLAP_VERBOSITY", "3")
+      assert {:ok, args} = Cheer.run(TestEnvVarCount, [])
+      assert args[:verbosity] === 3
+    after
+      System.delete_env("TEST_CLAP_VERBOSITY")
+    end
+
+    test "leaves a non-numeric env var as-is rather than crashing" do
+      System.put_env("TEST_CLAP_VERBOSITY", "loud")
+      assert {:ok, args} = Cheer.run(TestEnvVarCount, [])
+      assert args[:verbosity] == "loud"
+    after
+      System.delete_env("TEST_CLAP_VERBOSITY")
+    end
+
+    test "falls back to the integer default when no env var or flag" do
+      System.delete_env("TEST_CLAP_VERBOSITY")
+      assert {:ok, args} = Cheer.run(TestEnvVarCount, [])
+      assert args[:verbosity] === 0
+    end
+  end
+
   # -- Per-param validation ----------------------------------------------------
 
   defmodule TestValidation do


### PR DESCRIPTION
Closes #67

`coerce_env/2` (lib/cheer/router.ex) handled `:integer`, `:float`, `:boolean` explicitly and fell through to the raw string for every other type, including `:count`. A `:count` option backed by `:env` therefore received a string when the env var was set, while its `default` is the integer `0` — an inconsistent type depending on whether the flag, the env var, or the default supplied the value.

Added a `coerce_env(value, :count)` clause mirroring the existing `:integer` one (parse to integer, fall back to the raw string if it doesn't parse cleanly, rather than crashing).

- 3 new tests: numeric env var coerced to integer, non-numeric env var left as-is (no crash), default still used when neither flag nor env var is set.
- Full suite: 245/245 passed.
- `mix format --check-formatted` clean.