### PR TITLE
fix(router): treat numeric-looking tokens as num_args values

### DIFF
--- a/lib/cheer/router.ex
+++ b/lib/cheer/router.ex
@@ -797,12 +797,17 @@ defmodule Cheer.Router do
     do: {Enum.reverse(acc), tokens}
 
   defp take_num_args_values([token | rest], max, acc) do
-    if String.starts_with?(token, "-") and token != "-" do
+    if String.starts_with?(token, "-") and token != "-" and not numeric_looking?(token) do
       {Enum.reverse(acc), [token | rest]}
     else
       take_num_args_values(rest, max, [token | acc])
     end
   end
+
+  # A negative number ("-5", "-1.2") looks like a flag by prefix alone, but
+  # num_args collection should treat it as a value rather than stopping —
+  # otherwise `--range -5 5` can never supply a negative bound.
+  defp numeric_looking?(token), do: Regex.match?(~r/^-\d+(\.\d+)?$/, token)
 
   defp validate_num_args(num_args_values, options) do
     Enum.reduce_while(num_args_values, :ok, fn {name, values}, _acc ->

--- a/test/cheer_test.exs
+++ b/test/cheer_test.exs
@@ -626,6 +626,19 @@ defmodule CheerTest do
       assert output =~ "(2 values)"
       assert output =~ "(1..3 values)"
     end
+
+    test "negative numeric values are collected, not mistaken for flags (issue #64)" do
+      assert {:ok, %{point: [-5, 5]}} = Cheer.run(TestNumArgs, ["--point", "-5", "5"])
+    end
+
+    test "negative float values are collected as well" do
+      assert {:ok, %{tags: ["-1.5"]}} = Cheer.run(TestNumArgs, ["--tags", "-1.5"])
+    end
+
+    test "a real flag after a num_args option still stops collection" do
+      output = capture_io(fn -> Cheer.run(TestNumArgs, ["--point", "-5", "--verbose"]) end)
+      assert output =~ "--point expects 2 value(s), got 1"
+    end
   end
 
   # -- Usage-failure return value (issue #49) ----------------------------------


### PR DESCRIPTION
Closes #64

`take_num_args_values` stopped collecting at any token starting with `-` (except the bare `"-"`), so `--range -5 5` failed with `--range expects 2 value(s), got 0` — a negative number is indistinguishable from a flag by prefix alone.

Added a `numeric_looking?/1` guard (`^-\d+(\.\d+)?$`) so tokens like `-5`/`-1.2` are collected as values instead of stopping collection, while a real flag (`--verbose`, `-x`) still stops it.

- 3 new tests: negative integer values, negative float values, and confirming a real flag after a num_args option still stops collection correctly.
- Full suite: 245/245 passed.
- `mix format --check-formatted` clean.