### PR TITLE
feat(router): add :value_delimiter to split a single value into a list

### DIFF
--- a/lib/cheer/command/dsl.ex
+++ b/lib/cheer/command/dsl.ex
@@ -200,6 +200,10 @@ defmodule Cheer.Command.DSL do
       `--`. Distinct from `:multi`, which repeats the flag. An out-of-range count is a
       usage error.
     * `:env` - environment variable name to read as fallback
+    * `:value_delimiter` - split a single value on this delimiter into a list
+      (e.g. `value_delimiter: ","` turns `--tags a,b,c` into `["a", "b", "c"]`),
+      applying the option's `:type` coercion to each element. Combines with
+      `:multi` to flatten each occurrence's split values into one list.
     * `:choices` - list of allowed values
     * `:help` - help text shown in `--help`
     * `:long_help` - extended help text shown by `--help` (long form)

--- a/lib/cheer/help.ex
+++ b/lib/cheer/help.ex
@@ -275,6 +275,12 @@ defmodule Cheer.Help do
         spec -> suffixes ++ [num_args_label(spec)]
       end
 
+    suffixes =
+      case Keyword.get(opt_opts, :value_delimiter) do
+        nil -> suffixes
+        delimiter -> suffixes ++ ["(delimiter: '#{delimiter}')"]
+      end
+
     suffix = if suffixes != [], do: " " <> Enum.join(suffixes, " "), else: ""
 
     "  #{short}--#{String.pad_trailing(flag_name <> value_suffix, 16)} #{help}#{suffix}"

--- a/lib/cheer/router.ex
+++ b/lib/cheer/router.ex
@@ -842,7 +842,7 @@ defmodule Cheer.Router do
   defp build_option_parser_spec(options) do
     spec =
       Enum.map(options, fn {name, opts} ->
-        type = Keyword.get(opts, :type, :string)
+        type = parser_spec_type(opts)
 
         if Keyword.get(opts, :multi, false) do
           {name, [type, :keep]}
@@ -857,7 +857,7 @@ defmodule Cheer.Router do
       options
       |> Enum.filter(fn {_name, opts} -> Keyword.has_key?(opts, :aliases) end)
       |> Enum.flat_map(fn {_name, opts} ->
-        type = Keyword.get(opts, :type, :string)
+        type = parser_spec_type(opts)
 
         type_spec =
           if Keyword.get(opts, :multi, false), do: [type, :keep], else: type
@@ -873,9 +873,24 @@ defmodule Cheer.Router do
     {spec ++ alias_specs, aliases}
   end
 
+  # An option with :value_delimiter is split into elements *after* OptionParser
+  # hands back the raw flag value (build_parsed_map), so OptionParser itself
+  # must be told to treat it as a plain string — otherwise it would try (and
+  # fail) to coerce the whole "a,b,c" token to the option's real type before
+  # splitting ever happens.
+  defp parser_spec_type(opts) do
+    if Keyword.has_key?(opts, :value_delimiter) do
+      :string
+    else
+      Keyword.get(opts, :type, :string)
+    end
+  end
+
   defp build_parsed_map(parsed, options) do
     multi_names =
       for {name, opts} <- options, Keyword.get(opts, :multi, false), into: MapSet.new(), do: name
+
+    options_by_name = Map.new(options)
 
     # Build alias -> primary name mapping
     alias_map =
@@ -886,16 +901,37 @@ defmodule Cheer.Router do
       end)
       |> Map.new()
 
-    Enum.reduce(parsed, %{}, fn {key, value}, acc ->
+    Enum.reduce(parsed, %{}, fn {key, raw_value}, acc ->
       # Remap alias to primary name
       primary = Map.get(alias_map, key, key)
+      opts = Map.get(options_by_name, primary, [])
+      value = split_value_delimiter(raw_value, opts)
 
       if MapSet.member?(multi_names, primary) do
-        Map.update(acc, primary, [value], &(&1 ++ [value]))
+        Map.update(acc, primary, List.wrap(value), &(&1 ++ List.wrap(value)))
       else
         Map.put(acc, primary, value)
       end
     end)
+  end
+
+  # Splits a single "a,b,c"-shaped flag value into a coerced list, like clap's
+  # value_delimiter. Only applies when :value_delimiter is declared; other
+  # values pass through untouched (raw_value may not even be a string, e.g.
+  # a :boolean/:count value from OptionParser).
+  defp split_value_delimiter(raw_value, opts) do
+    case Keyword.get(opts, :value_delimiter) do
+      nil ->
+        raw_value
+
+      delimiter when is_binary(raw_value) ->
+        raw_value
+        |> String.split(delimiter)
+        |> Enum.map(&coerce_arg(&1, opts))
+
+      _delimiter ->
+        raw_value
+    end
   end
 
   # -- Output helpers --

--- a/test/cheer_test.exs
+++ b/test/cheer_test.exs
@@ -564,6 +564,56 @@ defmodule CheerTest do
     end
   end
 
+  # -- value_delimiter (issue #70) ---------------------------------------------
+
+  defmodule TestValueDelimiter do
+    use Cheer.Command
+
+    command "tagcmd" do
+      about("value_delimiter")
+
+      option(:tags, type: :string, value_delimiter: ",", help: "Tags")
+      option(:ids, type: :integer, value_delimiter: ",", help: "IDs")
+      option(:groups, type: :string, value_delimiter: ",", multi: true, help: "Groups")
+      option(:verbose, type: :boolean, help: "Verbose")
+    end
+
+    @impl Cheer.Command
+    def run(args, _raw), do: {:ok, args}
+  end
+
+  describe "value_delimiter (issue #70)" do
+    test "splits a single value into a list" do
+      assert {:ok, %{tags: ["a", "b", "c"]}} = Cheer.run(TestValueDelimiter, ["--tags", "a,b,c"])
+    end
+
+    test "a single value with no delimiter present still becomes a one-element list" do
+      assert {:ok, %{tags: ["solo"]}} = Cheer.run(TestValueDelimiter, ["--tags", "solo"])
+    end
+
+    test "applies the option's type coercion to each split element" do
+      assert {:ok, %{ids: [1, 2, 3]}} = Cheer.run(TestValueDelimiter, ["--ids", "1,2,3"])
+    end
+
+    test "works with --flag=value inline form" do
+      assert {:ok, %{tags: ["x", "y"]}} = Cheer.run(TestValueDelimiter, ["--tags=x,y"])
+    end
+
+    test "combines with :multi: each occurrence's split values are flattened together" do
+      assert {:ok, %{groups: ["a", "b", "c", "d"]}} =
+               Cheer.run(TestValueDelimiter, ["--groups", "a,b", "--groups", "c,d"])
+    end
+
+    test "an option without value_delimiter is unaffected" do
+      assert {:ok, %{verbose: true}} = Cheer.run(TestValueDelimiter, ["--verbose"])
+    end
+
+    test "shown in help text" do
+      output = capture_io(fn -> Cheer.run(TestValueDelimiter, ["--help"]) end)
+      assert output =~ "(delimiter: ',')"
+    end
+  end
+
   # -- num_args / multi-value options (issue #27) ------------------------------
 
   defmodule TestNumArgs do


### PR DESCRIPTION
Closes #70

Adds `:value_delimiter`, like clap's `value_delimiter(',')`: `--tags a,b,c` -> `["a", "b", "c"]`.

- `build_option_parser_spec`: an option declaring `:value_delimiter` is given a `:string` type spec regardless of its real `:type`, since OptionParser must hand back the raw "a,b,c" token before it can be split — otherwise OptionParser would try (and fail) to coerce the whole joined string to e.g. `:integer`.
- `build_parsed_map`: new `split_value_delimiter/2` splits the raw value on the delimiter and applies the option's real `:type` coercion (reusing the existing `coerce_arg/2`) to each element. Combines with `:multi`: each occurrence's split values are flattened into one list rather than nested.
- Rendered in help as `(delimiter: ',')`, documented in the `option/2` DSL doc.

- 7 new tests: basic split, no-delimiter-present single value, per-element type coercion, `--flag=value` inline form, combination with `:multi`, an unaffected option without the setting, and help rendering.
- Full suite: 249/249 passed.
- `mix format --check-formatted` clean.