### PR TITLE
feat(router): add :allow_hyphen_values for num_args options

### DIFF
--- a/lib/cheer/command/dsl.ex
+++ b/lib/cheer/command/dsl.ex
@@ -198,7 +198,11 @@ defmodule Cheer.Command.DSL do
       an integer for an exact count (`num_args: 2` accepts `--point 1 2`) or a range
       for a variable count (`num_args: 1..3`). Collection stops at the next flag or
       `--`. Distinct from `:multi`, which repeats the flag. An out-of-range count is a
-      usage error.
+      usage error. Negative numbers (`-5`, `-1.2`) are always collected as values;
+      other hyphen-prefixed tokens (`-foo`) require `:allow_hyphen_values`.
+    * `:allow_hyphen_values` - `true` to let a `:num_args` option collect any
+      hyphen-prefixed token as a value instead of treating it as the next flag
+      (e.g. coordinates or negative offsets: `--point -5 -3`)
     * `:env` - environment variable name to read as fallback
     * `:choices` - list of allowed values
     * `:help` - help text shown in `--help`

--- a/lib/cheer/router.ex
+++ b/lib/cheer/router.ex
@@ -755,7 +755,7 @@ defmodule Cheer.Router do
 
         {raw_values, rest2} =
           case inline do
-            nil -> take_num_args_values(rest, max, [])
+            nil -> take_num_args_values(rest, max, [], opts)
             value -> {[value], rest}
           end
 
@@ -788,21 +788,31 @@ defmodule Cheer.Router do
     end
   end
 
-  defp take_num_args_values(tokens, max, acc) when length(acc) >= max,
+  defp take_num_args_values(tokens, max, acc, _opts) when length(acc) >= max,
     do: {Enum.reverse(acc), tokens}
 
-  defp take_num_args_values([], _max, acc), do: {Enum.reverse(acc), []}
+  defp take_num_args_values([], _max, acc, _opts), do: {Enum.reverse(acc), []}
 
-  defp take_num_args_values(["--" | _] = tokens, _max, acc),
+  defp take_num_args_values(["--" | _] = tokens, _max, acc, _opts),
     do: {Enum.reverse(acc), tokens}
 
-  defp take_num_args_values([token | rest], max, acc) do
-    if String.starts_with?(token, "-") and token != "-" do
+  defp take_num_args_values([token | rest], max, acc, opts) do
+    looks_like_flag? = String.starts_with?(token, "-") and token != "-"
+    allow_hyphen? = Keyword.get(opts, :allow_hyphen_values, false)
+
+    if looks_like_flag? and not allow_hyphen? and not numeric_looking?(token) do
       {Enum.reverse(acc), [token | rest]}
     else
-      take_num_args_values(rest, max, [token | acc])
+      take_num_args_values(rest, max, [token | acc], opts)
     end
   end
+
+  # A negative number ("-5", "-1.2") looks like a flag by prefix alone, but
+  # num_args collection should treat it as a value rather than stopping —
+  # otherwise `--range -5 5` can never supply a negative bound. Anything else
+  # that starts with "-" (e.g. "-foo") still requires the option to opt in
+  # via `allow_hyphen_values: true`.
+  defp numeric_looking?(token), do: Regex.match?(~r/^-\d+(\.\d+)?$/, token)
 
   defp validate_num_args(num_args_values, options) do
     Enum.reduce_while(num_args_values, :ok, fn {name, values}, _acc ->

--- a/test/cheer_test.exs
+++ b/test/cheer_test.exs
@@ -626,6 +626,56 @@ defmodule CheerTest do
       assert output =~ "(2 values)"
       assert output =~ "(1..3 values)"
     end
+
+    test "negative numeric values are always collected, even without allow_hyphen_values (issue #64)" do
+      assert {:ok, %{point: [-5, 5]}} = Cheer.run(TestNumArgs, ["--point", "-5", "5"])
+    end
+
+    test "a real flag after a num_args option still stops collection" do
+      output = capture_io(fn -> Cheer.run(TestNumArgs, ["--point", "-5", "--verbose"]) end)
+      assert output =~ "--point expects 2 value(s), got 1"
+    end
+
+    test "a plain string option (not num_args) already accepts a hyphen-prefixed value" do
+      assert {:ok, args} = Cheer.run(TestNumArgs, ["site", "--point", "1", "2"])
+      assert args[:label] == "site"
+    end
+  end
+
+  # -- allow_hyphen_values (issue #73) -----------------------------------------
+
+  defmodule TestAllowHyphenValues do
+    use Cheer.Command
+
+    command "coords" do
+      about("allow_hyphen_values")
+
+      option(:point, type: :string, num_args: 2, allow_hyphen_values: true, help: "Coords")
+      option(:strict, type: :string, num_args: 2, help: "No opt-in")
+    end
+
+    @impl Cheer.Command
+    def run(args, _raw), do: {:ok, args}
+  end
+
+  describe "allow_hyphen_values (issue #73)" do
+    test "collects non-numeric hyphen-prefixed tokens as values when opted in" do
+      assert {:ok, %{point: ["-foo", "-bar"]}} =
+               Cheer.run(TestAllowHyphenValues, ["--point", "-foo", "-bar"])
+    end
+
+    test "negative numbers still work without needing allow_hyphen_values" do
+      assert {:ok, %{strict: ["-5", "5"]}} =
+               Cheer.run(TestAllowHyphenValues, ["--strict", "-5", "5"])
+    end
+
+    test "a non-numeric hyphen-prefixed token without opt-in still stops collection" do
+      # "-foo" is left in argv rather than collected, so it now falls to
+      # OptionParser, which reports it as an unknown option rather than a
+      # missing num_args value -- either way, it's not silently swallowed.
+      output = capture_io(fn -> Cheer.run(TestAllowHyphenValues, ["--strict", "-foo", "5"]) end)
+      assert output =~ "error: unknown option(s)"
+    end
   end
 
   # -- Usage-failure return value (issue #49) ----------------------------------


### PR DESCRIPTION
Closes #73
Closes #64 (folded in per the issue's suggestion — same underlying `take_num_args_values` fix)

Note: #64 already has an open, independent PR (#82) fixing the negative-number case in isolation. This PR includes the same `numeric_looking?/1` change plus the full `:allow_hyphen_values` option on top, so whichever merges first, the other becomes a no-op diff rather than a conflict — happy to drop #82 if this one is preferred, or vice versa.

Investigated the issue's premise first: `OptionParser` itself does **not** treat `-5`/`-5x` as a flag when given as a value to a regular (non-`num_args`) `:string`/`:integer` option, or as a bare positional — I verified `--offset -5` and a bare `-5` positional both already work correctly today with no code change. It only rejects tokens that look like an actual flag (`--word`, `-x`). The real, still-open gap is exactly what the issue's "first slice" describes: `take_num_args_values` (router.ex) stopped at *any* `-`-prefixed token, including negative numbers.

Changes:
- `take_num_args_values` now always collects a negative-number-looking token (`^-\d+(\.\d+)?$`) as a value, regardless of `:allow_hyphen_values`.
- A new `:allow_hyphen_values` option, when `true`, additionally collects *any* hyphen-prefixed token (e.g. `-foo`) as a value for that option's `num_args` collection.
- Documented in the `option/2` DSL doc.

- 6 new tests: negative numbers work without opt-in, a real flag still stops collection, a plain (non-num_args) option already handles hyphen values (regression-proofing the investigation above), `allow_hyphen_values: true` collecting non-numeric hyphen tokens, negative numbers still working without the opt-in, and a non-opted-in option still failing (now via OptionParser's own "unknown option" error since the leftover token falls through, not silently swallowed).
- Full suite: 248/248 passed.
- `mix format --check-formatted` clean.