### PR TITLE
fix(completion): bash/zsh/fish generators emit kebab-case flags

### DIFF
--- a/lib/cheer/completion.ex
+++ b/lib/cheer/completion.ex
@@ -118,7 +118,7 @@ defmodule Cheer.Completion do
 
   defp zsh_option_spec({name, opts}) do
     help = Keyword.get(opts, :help, "") |> escape_zsh()
-    "'--#{name}[#{help}]'"
+    "'--#{flag_name(name)}[#{help}]'"
   end
 
   defp escape_zsh(str), do: String.replace(str, "'", "'\\''")
@@ -148,7 +148,7 @@ defmodule Cheer.Completion do
         help = Keyword.get(opts, :help, "") |> escape_fish()
         short = Keyword.get(opts, :short)
         short_flag = if short, do: " -s #{short}", else: ""
-        "complete -c #{prog} -n '#{condition}' -l #{name}#{short_flag} -d '#{help}'"
+        "complete -c #{prog} -n '#{condition}' -l #{flag_name(name)}#{short_flag} -d '#{help}'"
       end)
 
     child_lines =
@@ -249,8 +249,9 @@ defmodule Cheer.Completion do
   # -- Helpers --
 
   defp option_completions({name, opts}) do
-    flags = ["--#{name}"]
-    flags = if Keyword.get(opts, :type) == :boolean, do: flags ++ ["--no-#{name}"], else: flags
+    flag = flag_name(name)
+    flags = ["--#{flag}"]
+    flags = if Keyword.get(opts, :type) == :boolean, do: flags ++ ["--no-#{flag}"], else: flags
     short = Keyword.get(opts, :short)
     if short, do: flags ++ ["-#{short}"], else: flags
   end
@@ -271,8 +272,8 @@ defmodule Cheer.Completion do
   end
 
   # Atom option names become kebab-case flags to match what the parser accepts
-  # (see `Cheer.Help.flag_from/1`). Used by the PowerShell generator; the other
-  # generators have a pre-existing underscore/hyphen inconsistency tracked separately.
+  # (see `Cheer.Help.flag_from/1`) — used by every generator, so a generated
+  # completion never suggests a flag the parser then rejects.
   defp flag_name(name) when is_atom(name), do: name |> Atom.to_string() |> flag_name()
   defp flag_name(name) when is_binary(name), do: String.replace(name, "_", "-")
 end

--- a/test/cheer_test.exs
+++ b/test/cheer_test.exs
@@ -1055,6 +1055,30 @@ defmodule CheerTest do
       assert script =~ "-p"
     end
 
+    test "bash renders multi-word option names as kebab-case, matching the parser (issue #65)" do
+      script = Cheer.Completion.generate(CheerTest.TestUnderscoreOption, :bash, prog: "under")
+      assert script =~ "--base-port"
+      assert script =~ "--replicas-per-master"
+      refute script =~ "--base_port"
+      refute script =~ "--replicas_per_master"
+    end
+
+    test "zsh renders multi-word option names as kebab-case, matching the parser (issue #65)" do
+      script = Cheer.Completion.generate(CheerTest.TestUnderscoreOption, :zsh, prog: "under")
+      assert script =~ "--base-port"
+      assert script =~ "--replicas-per-master"
+      refute script =~ "--base_port"
+      refute script =~ "--replicas_per_master"
+    end
+
+    test "fish renders multi-word option names as kebab-case, matching the parser (issue #65)" do
+      script = Cheer.Completion.generate(CheerTest.TestUnderscoreOption, :fish, prog: "under")
+      assert script =~ "-l base-port"
+      assert script =~ "-l replicas-per-master"
+      refute script =~ "base_port"
+      refute script =~ "replicas_per_master"
+    end
+
     test "generates powershell completion (#23)" do
       script = Cheer.Completion.generate(TestRoot, :powershell, prog: "myapp")
       assert script =~ "Register-ArgumentCompleter -Native -CommandName 'myapp'"


### PR DESCRIPTION
Closes #65

The bash, zsh, and fish completion generators interpolated the raw atom name (`--#{name}`) directly, so `option :base_port` produced a suggestion for `--base_port` — but the parser and `--help` use kebab-case (`--base-port`, via `Cheer.Help.flag_from/1`). Generated completions therefore suggested flags that fail to parse. Only the PowerShell generator already applied the existing private `flag_name/1` helper.

Applied the same `flag_name/1` kebab-case rendering across `option_completions/1` (bash), `zsh_option_spec/1` (zsh), and the fish `-l` option line — matching what PowerShell already did. Updated the stale comment on `flag_name/1` that described it as PowerShell-only.

- 3 new tests (one per shell) asserting a multi-word option name appears kebab-cased in each generated script, reusing the existing `TestUnderscoreOption` fixture.
- Full suite: 245/245 passed.
- `mix format --check-formatted` clean.