### PR TITLE
feat: add :parse for custom value parsers (option, argument, env, num_args)

### DIFF
--- a/lib/cheer/command.ex
+++ b/lib/cheer/command.ex
@@ -60,6 +60,7 @@ defmodule Cheer.Command do
       Module.register_attribute(__MODULE__, :cheer_options, accumulate: true)
       Module.register_attribute(__MODULE__, :cheer_subcommands, accumulate: true)
       Module.register_attribute(__MODULE__, :cheer_has_validate, accumulate: true)
+      Module.register_attribute(__MODULE__, :cheer_has_parse, accumulate: true)
       Module.register_attribute(__MODULE__, :cheer_groups, accumulate: true)
 
       # Counters for indexed function generation are managed at macro-expansion

--- a/lib/cheer/command/compiler.ex
+++ b/lib/cheer/command/compiler.ex
@@ -30,6 +30,7 @@ defmodule Cheer.Command.Compiler do
     options = Module.get_attribute(env.module, :cheer_options) |> Enum.reverse()
     subcommands = Module.get_attribute(env.module, :cheer_subcommands) |> Enum.reverse()
     has_validate = Module.get_attribute(env.module, :cheer_has_validate)
+    has_parse = Module.get_attribute(env.module, :cheer_has_parse)
     # Hook counters are incremented at macro-expansion time (see
     # Cheer.Command.DSL.next_hook_index/2). A command that declares no hooks of a
     # kind never writes the attribute, so default nil to 0.
@@ -70,37 +71,8 @@ defmodule Cheer.Command.Compiler do
     groups = build_groups(raw_groups)
 
     # Options: merge validate fns from generated functions
-    options_expr =
-      if has_validate == [] do
-        Macro.escape(options)
-      else
-        quote do
-          Enum.map(unquote(Macro.escape(options)), fn {n, o} ->
-            if n in unquote(has_validate) do
-              fname = :"__cheer_validate_#{n}__"
-              {n, Keyword.put(o, :validate, &apply(__MODULE__, fname, [&1]))}
-            else
-              {n, o}
-            end
-          end)
-        end
-      end
-
-    arguments_expr =
-      if has_validate == [] do
-        Macro.escape(arguments)
-      else
-        quote do
-          Enum.map(unquote(Macro.escape(arguments)), fn {n, o} ->
-            if n in unquote(has_validate) do
-              fname = :"__cheer_validate_#{n}__"
-              {n, Keyword.put(o, :validate, &apply(__MODULE__, fname, [&1]))}
-            else
-              {n, o}
-            end
-          end)
-        end
-      end
+    options_expr = wrap_validate_and_parse(Macro.escape(options), has_validate, has_parse)
+    arguments_expr = wrap_validate_and_parse(Macro.escape(arguments), has_validate, has_parse)
 
     validators_expr = make_indexed_fns(:__cheer_cross_validate__, validator_count)
     before_run_expr = make_indexed_fns(:__cheer_before_run__, before_run_count)
@@ -138,6 +110,64 @@ defmodule Cheer.Command.Compiler do
           groups: unquote(Macro.escape(groups))
         }
       end
+    end
+  end
+
+  # Wires the generated __cheer_validate_<name>__/__cheer_parse_<name>__
+  # functions into the escaped options/arguments list at compile time.
+  # Branches on has_validate/has_parse being [] here (a compile-time list),
+  # rather than emitting a runtime `n in []` check unconditionally, which
+  # would always be false for a command using only one of the two features
+  # and trip the compiler's "will always evaluate to false" type warning.
+  defp wrap_validate_and_parse(escaped_items, [], []), do: escaped_items
+
+  defp wrap_validate_and_parse(escaped_items, has_validate, []) do
+    quote do
+      Enum.map(unquote(escaped_items), fn {n, o} ->
+        if n in unquote(has_validate) do
+          fname = :"__cheer_validate_#{n}__"
+          {n, Keyword.put(o, :validate, &apply(__MODULE__, fname, [&1]))}
+        else
+          {n, o}
+        end
+      end)
+    end
+  end
+
+  defp wrap_validate_and_parse(escaped_items, [], has_parse) do
+    quote do
+      Enum.map(unquote(escaped_items), fn {n, o} ->
+        if n in unquote(has_parse) do
+          fname = :"__cheer_parse_#{n}__"
+          {n, Keyword.put(o, :parse, &apply(__MODULE__, fname, [&1]))}
+        else
+          {n, o}
+        end
+      end)
+    end
+  end
+
+  defp wrap_validate_and_parse(escaped_items, has_validate, has_parse) do
+    quote do
+      Enum.map(unquote(escaped_items), fn {n, o} ->
+        o =
+          if n in unquote(has_validate) do
+            fname = :"__cheer_validate_#{n}__"
+            Keyword.put(o, :validate, &apply(__MODULE__, fname, [&1]))
+          else
+            o
+          end
+
+        o =
+          if n in unquote(has_parse) do
+            fname = :"__cheer_parse_#{n}__"
+            Keyword.put(o, :parse, &apply(__MODULE__, fname, [&1]))
+          else
+            o
+          end
+
+        {n, o}
+      end)
     end
   end
 

--- a/lib/cheer/command/dsl.ex
+++ b/lib/cheer/command/dsl.ex
@@ -164,23 +164,39 @@ defmodule Cheer.Command.DSL do
     * `:value_name` - placeholder name in help (e.g. `"FILE"`)
     * `:hide` - `true` to hide from help output
     * `:display_order` - integer controlling position in help (lower first)
+    * `:parse` - `fn raw -> {:ok, value} | {:error, msg} end`; transforms the
+      built-in-coerced value into a domain value (atom, Date, URI, an enum...)
+      before `:validate` runs, so validators see the final parsed value
     * `:validate` - `fn value -> :ok | {:error, msg} end`
   """
   defmacro argument(name, opts \\ []) do
-    {validate_ast, clean_opts} = Keyword.pop(opts, :validate)
+    {validate_ast, opts} = Keyword.pop(opts, :validate)
+    {parse_ast, clean_opts} = Keyword.pop(opts, :parse)
 
-    if validate_ast do
-      fname = :"__cheer_validate_#{name}__"
+    validate_def =
+      if validate_ast do
+        fname = :"__cheer_validate_#{name}__"
 
-      quote do
-        @cheer_arguments {unquote(name), unquote(clean_opts)}
-        @cheer_has_validate unquote(name)
-        def unquote(fname)(val), do: unquote(validate_ast).(val)
+        quote do
+          @cheer_has_validate unquote(name)
+          def unquote(fname)(val), do: unquote(validate_ast).(val)
+        end
       end
-    else
-      quote do
-        @cheer_arguments {unquote(name), unquote(clean_opts)}
+
+    parse_def =
+      if parse_ast do
+        fname = :"__cheer_parse_#{name}__"
+
+        quote do
+          @cheer_has_parse unquote(name)
+          def unquote(fname)(val), do: unquote(parse_ast).(val)
+        end
       end
+
+    quote do
+      @cheer_arguments {unquote(name), unquote(clean_opts)}
+      unquote(validate_def)
+      unquote(parse_def)
     end
   end
 
@@ -215,6 +231,9 @@ defmodule Cheer.Command.DSL do
       any pair matches (i.e. `args[other_opt] == value`)
     * `:required_unless` - atom or list of atoms; this option is required unless any
       of the named options are present
+    * `:parse` - `fn raw -> {:ok, value} | {:error, msg} end`; transforms the
+      built-in-coerced value into a domain value (atom, Date, URI, an enum...)
+      before `:validate` runs, so validators see the final parsed value
     * `:validate` - `fn value -> :ok | {:error, msg} end`
 
   Boolean options automatically support `--no-<name>` negation (e.g. `--no-color`).
@@ -222,21 +241,34 @@ defmodule Cheer.Command.DSL do
   Extra positional arguments after `--` are collected into `args[:rest]`.
   """
   defmacro option(name, opts \\ []) do
-    {validate_ast, clean_opts} = Keyword.pop(opts, :validate)
+    {validate_ast, opts} = Keyword.pop(opts, :validate)
+    {parse_ast, clean_opts} = Keyword.pop(opts, :parse)
 
-    base =
+    validate_def =
       if validate_ast do
         fname = :"__cheer_validate_#{name}__"
 
         quote do
-          @cheer_options {unquote(name), unquote(clean_opts)}
           @cheer_has_validate unquote(name)
           def unquote(fname)(val), do: unquote(validate_ast).(val)
         end
-      else
+      end
+
+    parse_def =
+      if parse_ast do
+        fname = :"__cheer_parse_#{name}__"
+
         quote do
-          @cheer_options {unquote(name), unquote(clean_opts)}
+          @cheer_has_parse unquote(name)
+          def unquote(fname)(val), do: unquote(parse_ast).(val)
         end
+      end
+
+    base =
+      quote do
+        @cheer_options {unquote(name), unquote(clean_opts)}
+        unquote(validate_def)
+        unquote(parse_def)
       end
 
     quote do

--- a/lib/cheer/router.ex
+++ b/lib/cheer/router.ex
@@ -303,7 +303,7 @@ defmodule Cheer.Router do
                :ok <- validate_conditional_required(args, all_options, provided),
                :ok <- validate_constraints(all_options, provided),
                :ok <- validate_groups(provided, Map.get(meta, :groups, %{})),
-               :ok <- validate_params(args, all_options),
+               {:ok, args} <- validate_params(args, all_options ++ meta.arguments),
                :ok <- run_validators(args, Map.get(meta, :validators, [])) do
             {:ok, args}
           else
@@ -361,7 +361,7 @@ defmodule Cheer.Router do
           with :ok <- validate_conditional_required(args, all_options, provided),
                :ok <- validate_constraints(all_options, provided),
                :ok <- validate_groups(provided, Map.get(meta, :groups, %{})),
-               :ok <- validate_params(args, all_options),
+               {:ok, args} <- validate_params(args, all_options ++ meta.arguments),
                :ok <- run_validators(args, Map.get(meta, :validators, [])) do
             {:ok, args}
           else
@@ -579,20 +579,32 @@ defmodule Cheer.Router do
   # -- Per-param validation --
 
   defp validate_params(args, options) do
-    Enum.reduce_while(options, :ok, fn {name, opts}, _acc ->
-      case Map.fetch(args, name) do
+    Enum.reduce_while(options, {:ok, args}, fn {name, opts}, {:ok, acc_args} ->
+      case Map.fetch(acc_args, name) do
         {:ok, value} ->
           with :ok <- validate_choices(name, value, opts),
-               :ok <- validate_custom(name, value, opts) do
-            {:cont, :ok}
+               {:ok, parsed} <- apply_custom_parser(value, opts),
+               :ok <- validate_custom(name, parsed, opts) do
+            {:cont, {:ok, Map.put(acc_args, name, parsed)}}
           else
             {:error, msg} -> {:halt, {:error, msg}}
           end
 
         :error ->
-          {:cont, :ok}
+          {:cont, {:ok, acc_args}}
       end
     end)
+  end
+
+  # A :parse fun transforms the built-in-coerced value into a domain value
+  # (atom, Date, URI, enum...) after :choices has checked the raw value but
+  # before :validate runs, so custom validators see the final, parsed value
+  # rather than a string/number they'd have to re-parse themselves.
+  defp apply_custom_parser(value, opts) do
+    case Keyword.get(opts, :parse) do
+      nil -> {:ok, value}
+      fun when is_function(fun, 1) -> fun.(value)
+    end
   end
 
   defp validate_choices(name, value, opts) do

--- a/test/cheer_test.exs
+++ b/test/cheer_test.exs
@@ -525,6 +525,77 @@ defmodule CheerTest do
     end
   end
 
+  defmodule TestCustomParser do
+    use Cheer.Command
+
+    command "parsecmd" do
+      about("Custom :parse")
+
+      option(:level,
+        type: :string,
+        parse: fn
+          "low" -> {:ok, :low}
+          "high" -> {:ok, :high}
+          other -> {:error, "invalid level: #{other}"}
+        end,
+        validate: fn
+          :low -> :ok
+          :high -> {:error, "high is temporarily disabled"}
+        end,
+        help: "Level"
+      )
+
+      option(:count, type: :integer, parse: fn v -> {:ok, v * 2} end, help: "Doubled count")
+
+      argument(:mode,
+        type: :string,
+        required: false,
+        parse: fn v -> {:ok, String.upcase(v)} end
+      )
+
+      option(:env_level,
+        type: :string,
+        env: "TEST_CLAP_PARSE_LEVEL",
+        parse: fn v -> {:ok, String.to_atom(v)} end
+      )
+    end
+
+    @impl Cheer.Command
+    def run(args, _raw), do: {:ok, args}
+  end
+
+  describe "custom :parse (issue #72)" do
+    test "transforms the coerced value into a domain value" do
+      assert {:ok, %{level: :low}} = Cheer.run(TestCustomParser, ["--level", "low"])
+    end
+
+    test "a parse error is reported and short-circuits the pipeline" do
+      output = capture_io(fn -> Cheer.run(TestCustomParser, ["--level", "medium"]) end)
+      assert output =~ "invalid level: medium"
+    end
+
+    test "parse runs before validate, so validate sees the parsed value" do
+      output = capture_io(fn -> Cheer.run(TestCustomParser, ["--level", "high"]) end)
+      assert output =~ "high is temporarily disabled"
+    end
+
+    test "parse applies to a plain integer-typed option too" do
+      assert {:ok, %{count: 6}} = Cheer.run(TestCustomParser, ["--level", "low", "--count", "3"])
+    end
+
+    test "parse applies to a positional argument" do
+      assert {:ok, %{mode: "CLI"}} = Cheer.run(TestCustomParser, ["--level", "low", "cli"])
+    end
+
+    test "parse applies to a value supplied via :env fallback" do
+      System.put_env("TEST_CLAP_PARSE_LEVEL", "prod")
+      assert {:ok, args} = Cheer.run(TestCustomParser, ["--level", "low"])
+      assert args[:env_level] == :prod
+    after
+      System.delete_env("TEST_CLAP_PARSE_LEVEL")
+    end
+  end
+
   # -- Non-literal opt values (issue #48) --------------------------------------
 
   defmodule TestSigilChoices do


### PR DESCRIPTION
Closes #72

Adds `:parse`, like clap's `value_parser`: a 1-arity fun `raw -> {:ok, value} | {:error, msg}` applied after built-in coercion, letting an option/argument convert a raw string into a domain value (atom, Date, URI, enum...) instead of every caller re-parsing fields in `run/2`.

- **DSL** (`option/2`, `argument/2`): `:parse` is popped out and compiled into a generated `__cheer_parse_<name>__/1` function, the same mechanism already used for `:validate` (anonymous functions can't survive `Macro.escape/1`, which is why this can't just be a keyword value like `:choices`). Extracted the combined validate+parse wiring in `compiler.ex` into `wrap_validate_and_parse/3`, branching at compile time on whether each list is empty rather than emitting an always-false `n in []` check for commands that only use one of the two — the naive combined version tripped Elixir's new type-checker warning on every existing `:validate`-only command.
- **Wiring**: implemented as a single change in `validate_params/2` (router.ex) — after `:choices` checks the raw value, `:parse` runs (returning `{:ok, new_args}` to thread the transformed value forward), then `:validate` runs on the parsed value. Since `validate_params` is the common point every value passes through regardless of *how* it got into `args` (a flag, a `num_args` collection, a positional, or an `:env` fallback), this one change covers all four paths the issue asks for — verified each explicitly in tests rather than assuming.
- While wiring this through `parse_standard`, found `validate_params` was only ever called with `all_options`, missing `meta.arguments` — the same gap independently found and already fixed by #85 (issue #69). Included here too since #72 doesn't work for arguments without it (whichever PR merges first, the other's overlapping hunk becomes a no-op).

- 6 new tests: option parse, parse-error short-circuits the pipeline with the fn's own message, parse runs before validate (validate sees the parsed value), parse on an integer-typed option, parse on a positional argument, and parse on an `:env`-sourced value.
- Full suite: 248/248 passed, zero compiler warnings (verified the `n in []` warning is gone with `mix compile --force`).
- `mix format --check-formatted` clean.