### PR TITLE
fix: kebab-case option flags in bash/zsh/fish completions

### DIFF
--- a/lib/cheer/completion.ex
+++ b/lib/cheer/completion.ex
@@ -118,7 +118,7 @@ defmodule Cheer.Completion do
 
   defp zsh_option_spec({name, opts}) do
     help = Keyword.get(opts, :help, "") |> escape_zsh()
-    "'--#{name}[#{help}]'"
+    "'--#{flag_name(name)}[#{help}]'"
   end
 
   defp escape_zsh(str), do: String.replace(str, "'", "'\\''")
@@ -148,7 +148,7 @@ defmodule Cheer.Completion do
         help = Keyword.get(opts, :help, "") |> escape_fish()
         short = Keyword.get(opts, :short)
         short_flag = if short, do: " -s #{short}", else: ""
-        "complete -c #{prog} -n '#{condition}' -l #{name}#{short_flag} -d '#{help}'"
+        "complete -c #{prog} -n '#{condition}' -l #{flag_name(name)}#{short_flag} -d '#{help}'"
       end)
 
     child_lines =
@@ -249,8 +249,9 @@ defmodule Cheer.Completion do
   # -- Helpers --
 
   defp option_completions({name, opts}) do
-    flags = ["--#{name}"]
-    flags = if Keyword.get(opts, :type) == :boolean, do: flags ++ ["--no-#{name}"], else: flags
+    flag = flag_name(name)
+    flags = ["--#{flag}"]
+    flags = if Keyword.get(opts, :type) == :boolean, do: flags ++ ["--no-#{flag}"], else: flags
     short = Keyword.get(opts, :short)
     if short, do: flags ++ ["-#{short}"], else: flags
   end
@@ -271,8 +272,8 @@ defmodule Cheer.Completion do
   end
 
   # Atom option names become kebab-case flags to match what the parser accepts
-  # (see `Cheer.Help.flag_from/1`). Used by the PowerShell generator; the other
-  # generators have a pre-existing underscore/hyphen inconsistency tracked separately.
+  # (see `Cheer.Help.flag_from/1`). Used by every generator so completions never
+  # suggest a flag the parser would reject.
   defp flag_name(name) when is_atom(name), do: name |> Atom.to_string() |> flag_name()
   defp flag_name(name) when is_binary(name), do: String.replace(name, "_", "-")
 end

--- a/test/cheer_test.exs
+++ b/test/cheer_test.exs
@@ -1095,6 +1095,28 @@ defmodule CheerTest do
       refute script =~ "'--base_port'"
     end
 
+    test "bash/zsh/fish flag names are kebab-cased to match the parser (#65)" do
+      defmodule TestShellUnderscores do
+        use Cheer.Command
+
+        command "app" do
+          about("App")
+          option(:base_port, type: :integer, help: "Base port")
+          option(:dry_run, type: :boolean, help: "Dry run")
+        end
+
+        @impl Cheer.Command
+        def run(_args, _raw), do: :ok
+      end
+
+      for shell <- [:bash, :zsh, :fish] do
+        script = Cheer.Completion.generate(TestShellUnderscores, shell, prog: "app")
+        assert script =~ "base-port", "#{shell} should emit kebab-case flag"
+        refute script =~ "base_port", "#{shell} should not leak the underscore flag"
+        assert script =~ "dry-run", "#{shell} should emit kebab-case boolean flag"
+      end
+    end
+
     test "powershell completion escapes single quotes in help text (#23)" do
       defmodule TestPwshQuotes do
         use Cheer.Command


### PR DESCRIPTION
Closes #65.

## Problem

The bash, zsh, and fish completion generators interpolated the raw atom option name (`--#{name}`), so `option :base_port` produced `--base_port`, while the parser and `--help` use kebab-case (`--base-port`). Generated completions suggested flags the parser rejects. Only the PowerShell generator applied `flag_name/1`.

## Fix

Apply the existing `flag_name/1` kebab-case helper in all three generators (`zsh_option_spec/1`, the fish `-l` line, and bash `option_completions/1`, including the `--no-` boolean form). Updated the helper comment that previously called this a known inconsistency "tracked separately."

## Test

Added a `#65` test asserting a multi-word option (`:base_port`, `:dry_run`) renders kebab-cased and never leaks the underscore form across bash, zsh, and fish. Full suite green.