### PR TITLE
fix: argument-level validate and choices were never run

### DIFF
--- a/lib/cheer/router.ex
+++ b/lib/cheer/router.ex
@@ -303,7 +303,8 @@ defmodule Cheer.Router do
                :ok <- validate_conditional_required(args, all_options, provided),
                :ok <- validate_constraints(all_options, provided),
                :ok <- validate_groups(provided, Map.get(meta, :groups, %{})),
-               :ok <- validate_params(args, all_options),
+               # Include arguments so argument-level :validate and :choices run.
+               :ok <- validate_params(args, all_options ++ meta.arguments),
                :ok <- run_validators(args, Map.get(meta, :validators, [])) do
             {:ok, args}
           else
@@ -361,7 +362,8 @@ defmodule Cheer.Router do
           with :ok <- validate_conditional_required(args, all_options, provided),
                :ok <- validate_constraints(all_options, provided),
                :ok <- validate_groups(provided, Map.get(meta, :groups, %{})),
-               :ok <- validate_params(args, all_options),
+               # Include arguments so argument-level :validate and :choices run.
+               :ok <- validate_params(args, all_options ++ meta.arguments),
                :ok <- run_validators(args, Map.get(meta, :validators, [])) do
             {:ok, args}
           else

--- a/test/cheer_test.exs
+++ b/test/cheer_test.exs
@@ -525,6 +525,56 @@ defmodule CheerTest do
     end
   end
 
+  # -- Argument-level validate and choices (#69 bug) ---------------------------
+
+  defmodule TestArgValidate do
+    use Cheer.Command
+
+    command "av" do
+      argument(:port,
+        type: :integer,
+        required: true,
+        validate: fn p -> if p > 0, do: :ok, else: {:error, "port must be positive"} end
+      )
+    end
+
+    @impl Cheer.Command
+    def run(args, _raw), do: {:ok, args}
+  end
+
+  defmodule TestArgChoices do
+    use Cheer.Command
+
+    command "ac" do
+      argument(:env, type: :string, required: true, choices: ["dev", "prod"])
+    end
+
+    @impl Cheer.Command
+    def run(args, _raw), do: {:ok, args}
+  end
+
+  describe "argument-level validate and choices (#69)" do
+    test "argument :validate rejects an invalid value" do
+      out = capture_io(fn -> assert Cheer.run(TestArgValidate, ["-5"]) == {:error, :usage} end)
+      assert out =~ "port must be positive"
+    end
+
+    test "argument :validate accepts a valid value" do
+      assert {:ok, %{port: 8080}} = Cheer.run(TestArgValidate, ["8080"])
+    end
+
+    test "argument :choices rejects a value outside the set" do
+      out =
+        capture_io(fn -> assert Cheer.run(TestArgChoices, ["staging"]) == {:error, :usage} end)
+
+      assert out =~ "must be one of"
+    end
+
+    test "argument :choices accepts a value in the set" do
+      assert {:ok, %{env: "prod"}} = Cheer.run(TestArgChoices, ["prod"])
+    end
+  end
+
   # -- Non-literal opt values (issue #48) --------------------------------------
 
   defmodule TestSigilChoices do


### PR DESCRIPTION
Relates to #69 (this is the correctness bug surfaced during the audit review, split out from the broader test-coverage work).

## Bug

A positional `argument` declared with `:validate` (or `:choices`) had its validator silently ignored: the value was accepted regardless.

Reproduced on main:
```elixir
argument :port, type: :integer, required: true,
  validate: fn p -> if p > 0, do: :ok, else: {:error, "port must be positive"} end
# Cheer.run(cmd, ["-5"])  =>  {:ok, %{port: -5}}   (validator never fired)
```

## Root cause

The DSL and compiler correctly generate `__cheer_validate_<name>__` and attach the wrapped validator into each argument's opts in `meta.arguments`. But both dispatch paths called `validate_params(args, all_options)`, passing only options and never `meta.arguments`, so the attached argument validators (and `:choices`) were never handed to the per-param validation pass. A pure router omission, not a DSL/compiler defect.

## Fix

Pass argument metadata to the per-param validation pass in both `parse_standard` and `parse_with_external_subcommand`. This makes argument-level `:validate` and `:choices` run. Adds tests for both, plus the pass-through (good value) case.

Discovered during review of the audit backlog. Release-relevant for 0.1.6.