### PR TITLE
fix(router): coerce :count env fallback and support num_args on external subcommands

### DIFF
--- a/lib/cheer/router.ex
+++ b/lib/cheer/router.ex
@@ -337,7 +337,15 @@ defmodule Cheer.Router do
       end)
 
     all_options = meta.options ++ inherited_globals
-    {option_parser_opts, option_aliases} = build_option_parser_spec(all_options)
+
+    # Pull num_args flags out first (head mode: stop at the external subcommand),
+    # then parse the remainder. OptionParser cannot express multi-value flags.
+    {num_args_values, argv} = extract_num_args(argv, all_options, true)
+
+    parser_options =
+      Enum.reject(all_options, fn {_name, o} -> Keyword.has_key?(o, :num_args) end)
+
+    {option_parser_opts, option_aliases} = build_option_parser_spec(parser_options)
 
     {parsed, positional, invalid} =
       OptionParser.parse_head(argv, strict: option_parser_opts, aliases: option_aliases)
@@ -350,6 +358,7 @@ defmodule Cheer.Router do
       args = apply_defaults(all_options)
       args = apply_env_vars(args, all_options)
       args = Map.merge(args, parsed_map)
+      args = Map.merge(args, num_args_values)
 
       args =
         case positional do
@@ -357,7 +366,7 @@ defmodule Cheer.Router do
           [name | rest] -> Map.put(args, :external_subcommand, {name, rest})
         end
 
-      provided = MapSet.new(Map.keys(parsed_map))
+      provided = MapSet.new(Map.keys(parsed_map) ++ Map.keys(num_args_values))
 
       missing = missing_required_options(all_options, args)
 
@@ -367,7 +376,8 @@ defmodule Cheer.Router do
           :handled
 
         true ->
-          with :ok <- validate_conditional_required(args, all_options, provided),
+          with :ok <- validate_num_args(num_args_values, all_options),
+               :ok <- validate_conditional_required(args, all_options, provided),
                :ok <- validate_constraints(all_options, provided),
                :ok <- validate_groups(provided, Map.get(meta, :groups, %{})),
                # Include arguments so argument-level :validate and :choices run.
@@ -587,6 +597,17 @@ defmodule Cheer.Router do
   end
 
   defp coerce_env(value, :boolean), do: value in ["true", "1", "yes"]
+
+  # A :count option is always an integer (its default is 0), so an env fallback
+  # must be coerced too. An unparseable value floors to 0 rather than leaking a
+  # string into run/2.
+  defp coerce_env(value, :count) do
+    case Integer.parse(value) do
+      {n, ""} -> n
+      _ -> 0
+    end
+  end
+
   defp coerce_env(value, _), do: value
 
   # -- Per-param validation --
@@ -727,13 +748,17 @@ defmodule Cheer.Router do
   # tokens out of argv and returns `{%{point: [1, 2, 3]}, residual_argv}`.
   # Collection stops at the next flag-looking token (one starting with "-"),
   # at "--", or once `max` values are taken.
-  defp extract_num_args(argv, options) do
+  #
+  # `head?` mirrors OptionParser.parse_head: when true (external_subcommands),
+  # extraction stops at the first positional token so the external subcommand
+  # name and its args are left untouched for parse_head.
+  defp extract_num_args(argv, options, head? \\ false) do
     num_args_opts = Enum.filter(options, fn {_name, o} -> Keyword.has_key?(o, :num_args) end)
 
     if num_args_opts == [] do
       {%{}, argv}
     else
-      do_extract_num_args(argv, num_args_lookup(num_args_opts), %{}, [])
+      do_extract_num_args(argv, num_args_lookup(num_args_opts), %{}, [], head?)
     end
   end
 
@@ -802,13 +827,13 @@ defmodule Cheer.Router do
     |> Map.new()
   end
 
-  defp do_extract_num_args([], _lookup, collected, residual),
+  defp do_extract_num_args([], _lookup, collected, residual, _head?),
     do: {collected, Enum.reverse(residual)}
 
-  defp do_extract_num_args(["--" | rest], _lookup, collected, residual),
+  defp do_extract_num_args(["--" | rest], _lookup, collected, residual, _head?),
     do: {collected, Enum.reverse(residual) ++ ["--" | rest]}
 
-  defp do_extract_num_args([token | rest], lookup, collected, residual) do
+  defp do_extract_num_args([token | rest] = all, lookup, collected, residual, head?) do
     case num_args_flag(token, lookup) do
       {{name, opts}, inline} ->
         {_min, max} = num_args_bounds(Keyword.fetch!(opts, :num_args))
@@ -823,10 +848,17 @@ defmodule Cheer.Router do
           end
 
         values = Enum.map(raw_values, &coerce_arg(&1, opts))
-        do_extract_num_args(rest2, lookup, Map.put(collected, name, values), residual)
+        do_extract_num_args(rest2, lookup, Map.put(collected, name, values), residual, head?)
 
       :nomatch ->
-        do_extract_num_args(rest, lookup, collected, [token | residual])
+        # In head mode the first positional is the external subcommand: stop and
+        # hand it (plus the rest) to parse_head. Option-looking tokens are parent
+        # flags, so keep scanning past them.
+        if head? and not String.starts_with?(token, "-") do
+          {collected, Enum.reverse(residual) ++ all}
+        else
+          do_extract_num_args(rest, lookup, collected, [token | residual], head?)
+        end
     end
   end
 

--- a/test/cheer_test.exs
+++ b/test/cheer_test.exs
@@ -1340,6 +1340,17 @@ defmodule CheerTest do
     def run(args, _raw), do: {:ok, args}
   end
 
+  defmodule TestCountEnv do
+    use Cheer.Command
+
+    command "ce" do
+      option(:level, type: :count, env: "TEST_CHEER_LEVEL")
+    end
+
+    @impl Cheer.Command
+    def run(args, _raw), do: {:ok, args}
+  end
+
   describe "count type" do
     test "single flag" do
       assert {:ok, args} = Cheer.run(TestCount, ["hello", "-v"])
@@ -1364,6 +1375,20 @@ defmodule CheerTest do
     test "help text shows repeatable" do
       output = capture_io(fn -> Cheer.run(TestCount, ["--help"]) end)
       assert output =~ "(repeatable)"
+    end
+
+    test "env fallback coerces to an integer (#67)" do
+      System.put_env("TEST_CHEER_LEVEL", "4")
+      assert {:ok, %{level: 4}} = Cheer.run(TestCountEnv, [])
+    after
+      System.delete_env("TEST_CHEER_LEVEL")
+    end
+
+    test "unparseable env fallback floors to 0 (#67)" do
+      System.put_env("TEST_CHEER_LEVEL", "nope")
+      assert {:ok, %{level: 0}} = Cheer.run(TestCountEnv, [])
+    after
+      System.delete_env("TEST_CHEER_LEVEL")
     end
   end
 
@@ -2808,6 +2833,52 @@ defmodule CheerTest do
     test "commands with subcommands and no external_subcommands still error on unknown tokens (regression)" do
       output = capture_io(fn -> Cheer.run(TestNoExternalSub, ["surprise"]) end)
       assert output =~ "error: unknown command 'surprise'"
+    end
+  end
+
+  # -- num_args with external_subcommands (#66) --------------------------------
+
+  defmodule TestExternalNumArgs do
+    use Cheer.Command
+
+    command "tool" do
+      about("External dispatcher with a num_args option")
+      external_subcommands(true)
+      option(:point, type: :integer, num_args: 2, help: "Two coords")
+      option(:verbose, type: :boolean, short: :v)
+    end
+
+    @impl Cheer.Command
+    def run(args, _raw), do: {:ok, args}
+  end
+
+  describe "num_args with external_subcommands (#66)" do
+    test "num_args flag before the external name is collected" do
+      assert {:ok, args} =
+               Cheer.run(TestExternalNumArgs, ["--point", "1", "2", "deploy", "--foo"])
+
+      assert args[:point] == [1, 2]
+      assert args[:external_subcommand] == {"deploy", ["--foo"]}
+    end
+
+    test "num_args mixes with other parent options before the external name" do
+      assert {:ok, args} =
+               Cheer.run(TestExternalNumArgs, ["--verbose", "--point", "5", "6", "deploy", "x"])
+
+      assert args[:verbose] == true
+      assert args[:point] == [5, 6]
+      assert args[:external_subcommand] == {"deploy", ["x"]}
+    end
+
+    test "a num_args flag after the external name is passed through, not consumed" do
+      assert {:ok, args} = Cheer.run(TestExternalNumArgs, ["deploy", "--point", "1", "2"])
+      assert args[:point] == nil
+      assert args[:external_subcommand] == {"deploy", ["--point", "1", "2"]}
+    end
+
+    test "an underprovided num_args flag is a usage error" do
+      output = capture_io(fn -> Cheer.run(TestExternalNumArgs, ["--point", "1"]) end)
+      assert output =~ "--point expects 2 value(s)"
     end
   end
 


### PR DESCRIPTION
Closes #66. Closes #67.

Two audit fixes in the parsing pipeline.

## #67 env `:count` coercion

A `:count` option backed by `:env` received the raw string instead of an integer, inconsistent with its integer default of `0`. Added a `coerce_env(_, :count)` clause that parses to integer and floors an unparseable value to `0`.

## #66 num_args on `external_subcommands`

`parse_with_external_subcommand` never called `extract_num_args`, so `num_args` options were silently ignored with `external_subcommands: true`.

Rather than duplicate the extraction (the closed community version added ~30 near-identical lines), I added a `head?` flag to the existing `extract_num_args`: in head mode it stops at the first positional token, leaving the external subcommand name and its args untouched for `parse_head`. Verified `--point 1 2 deploy --foo` yields `point: [1, 2]`, `external_subcommand: {"deploy", ["--foo"]}`; a num_args flag after the external name passes through; an underprovided count still errors.

Tests added for both. Full suite green.