### PR TITLE
feat: allow_hyphen_values for options, plus negative numbers in num_args

### DIFF
--- a/docs/guides/options.md
+++ b/docs/guides/options.md
@@ -73,6 +73,24 @@ range is a usage error:
 This is distinct from `:multi`, which repeats the whole flag (`--tag a --tag b`)
 rather than consuming multiple tokens after one flag.
 
+## Hyphen-leading values (`:allow_hyphen_values`)
+
+A value that starts with `-` normally looks like a flag, so it is rejected.
+Negative numbers are always accepted (`--range -5 5`). For other hyphen-leading
+values, set `:allow_hyphen_values`:
+
+```elixir
+option :pattern, type: :string, allow_hyphen_values: true
+# --pattern -v   ->  args[:pattern] == "-v"
+
+option :range, type: :integer, num_args: 2, allow_hyphen_values: true
+# --range -a -b  ->  args[:range] == ["-a", "-b"]
+```
+
+A single-value option consumes exactly the next token as its value, so a
+following flag is still parsed normally (`--pattern x --verbose`). With
+`:num_args`, collection consumes hyphen-leading tokens up to the declared count.
+
 ## Aliases (long-form)
 
 ```elixir

--- a/lib/cheer/command/dsl.ex
+++ b/lib/cheer/command/dsl.ex
@@ -198,7 +198,10 @@ defmodule Cheer.Command.DSL do
       an integer for an exact count (`num_args: 2` accepts `--point 1 2`) or a range
       for a variable count (`num_args: 1..3`). Collection stops at the next flag or
       `--`. Distinct from `:multi`, which repeats the flag. An out-of-range count is a
-      usage error.
+      usage error. Negative numbers are always accepted as values (`--range -5 5`).
+    * `:allow_hyphen_values` - `true` to accept a value that starts with `-`, such
+      as `--pattern -v` or `--range -a -b` (with `num_args`). Without it, only
+      negative numbers are accepted as hyphen-leading values.
     * `:env` - environment variable name to read as fallback
     * `:choices` - list of allowed values
     * `:help` - help text shown in `--help`

--- a/lib/cheer/router.ex
+++ b/lib/cheer/router.ex
@@ -227,12 +227,16 @@ defmodule Cheer.Router do
     all_options = meta.options ++ inherited_globals
 
     # Options declared with `num_args:` accept several values per flag, which
-    # OptionParser cannot express. Pull them (and their value tokens) out of
-    # argv up front, then parse the remainder normally.
+    # OptionParser cannot express. Options with `allow_hyphen_values:` accept a
+    # value starting with `-`, which OptionParser would read as a flag. Pull both
+    # (and their value tokens) out of argv up front, then parse the remainder.
     {num_args_values, argv} = extract_num_args(argv, all_options)
+    {hyphen_values, argv} = extract_hyphen_values(argv, all_options)
 
     parser_options =
-      Enum.reject(all_options, fn {_name, o} -> Keyword.has_key?(o, :num_args) end)
+      Enum.reject(all_options, fn {_name, o} = opt ->
+        Keyword.has_key?(o, :num_args) or single_value_hyphen_opt?(opt)
+      end)
 
     {option_parser_opts, option_aliases} = build_option_parser_spec(parser_options)
 
@@ -248,6 +252,7 @@ defmodule Cheer.Router do
       args = apply_env_vars(args, all_options)
       args = Map.merge(args, parsed_map)
       args = Map.merge(args, num_args_values)
+      args = Map.merge(args, hyphen_values)
 
       {declared_positional, rest_args} = Enum.split(positional, length(meta.arguments))
 
@@ -268,7 +273,10 @@ defmodule Cheer.Router do
       # Map.has_key?/2 so that defaults, :count (0), and :multi ([]) do not read
       # as "provided". Env fallback is intentionally not counted as user input.
       provided =
-        MapSet.new(Map.keys(parsed_map) ++ Map.keys(num_args_values) ++ supplied_positional)
+        MapSet.new(
+          Map.keys(parsed_map) ++
+            Map.keys(num_args_values) ++ Map.keys(hyphen_values) ++ supplied_positional
+        )
 
       args =
         case meta[:trailing_var_arg] do
@@ -729,6 +737,53 @@ defmodule Cheer.Router do
     end
   end
 
+  # Options with `allow_hyphen_values: true` that take a single value (not
+  # num_args, boolean, or count) must have their value pulled out before
+  # OptionParser, which would otherwise treat a `-`-prefixed value as a flag.
+  defp extract_hyphen_values(argv, options) do
+    hyphen_opts = Enum.filter(options, &single_value_hyphen_opt?/1)
+
+    if hyphen_opts == [] do
+      {%{}, argv}
+    else
+      do_extract_hyphen_values(argv, num_args_lookup(hyphen_opts), %{}, [])
+    end
+  end
+
+  defp single_value_hyphen_opt?({_name, o}) do
+    Keyword.get(o, :allow_hyphen_values, false) and
+      not Keyword.has_key?(o, :num_args) and
+      Keyword.get(o, :type, :string) not in [:boolean, :count]
+  end
+
+  defp do_extract_hyphen_values([], _lookup, collected, residual),
+    do: {collected, Enum.reverse(residual)}
+
+  defp do_extract_hyphen_values(["--" | rest], _lookup, collected, residual),
+    do: {collected, Enum.reverse(residual) ++ ["--" | rest]}
+
+  defp do_extract_hyphen_values([token | rest], lookup, collected, residual) do
+    case num_args_flag(token, lookup) do
+      {{name, opts}, nil} ->
+        case rest do
+          [value | rest2] ->
+            collected = Map.put(collected, name, coerce_arg(value, opts))
+            do_extract_hyphen_values(rest2, lookup, collected, residual)
+
+          [] ->
+            # Flag with no following value: leave it for the normal parse path.
+            do_extract_hyphen_values([], lookup, collected, [token | residual])
+        end
+
+      {{name, opts}, inline} ->
+        collected = Map.put(collected, name, coerce_arg(inline, opts))
+        do_extract_hyphen_values(rest, lookup, collected, residual)
+
+      :nomatch ->
+        do_extract_hyphen_values(rest, lookup, collected, [token | residual])
+    end
+  end
+
   defp num_args_lookup(num_args_opts) do
     Enum.flat_map(num_args_opts, fn {name, opts} = entry ->
       long = [{"--#{flag_string(name)}", entry}]
@@ -760,8 +815,11 @@ defmodule Cheer.Router do
 
         {raw_values, rest2} =
           case inline do
-            nil -> take_num_args_values(rest, max, [])
-            value -> {[value], rest}
+            nil ->
+              take_num_args_values(rest, max, [], Keyword.get(opts, :allow_hyphen_values, false))
+
+            value ->
+              {[value], rest}
           end
 
         values = Enum.map(raw_values, &coerce_arg(&1, opts))
@@ -793,21 +851,27 @@ defmodule Cheer.Router do
     end
   end
 
-  defp take_num_args_values(tokens, max, acc) when length(acc) >= max,
+  defp take_num_args_values(tokens, max, acc, _allow_hyphen?) when length(acc) >= max,
     do: {Enum.reverse(acc), tokens}
 
-  defp take_num_args_values([], _max, acc), do: {Enum.reverse(acc), []}
+  defp take_num_args_values([], _max, acc, _allow_hyphen?), do: {Enum.reverse(acc), []}
 
-  defp take_num_args_values(["--" | _] = tokens, _max, acc),
+  defp take_num_args_values(["--" | _] = tokens, _max, acc, _allow_hyphen?),
     do: {Enum.reverse(acc), tokens}
 
-  defp take_num_args_values([token | rest], max, acc) do
-    if String.starts_with?(token, "-") and token != "-" do
+  defp take_num_args_values([token | rest], max, acc, allow_hyphen?) do
+    # Stop at a flag-looking token, unless the option opted into hyphen values or
+    # the token is a negative number (always a value in a num_args context, never
+    # a flag).
+    if flag_like?(token) and not allow_hyphen? and not negative_number?(token) do
       {Enum.reverse(acc), [token | rest]}
     else
-      take_num_args_values(rest, max, [token | acc])
+      take_num_args_values(rest, max, [token | acc], allow_hyphen?)
     end
   end
+
+  defp flag_like?(token), do: String.starts_with?(token, "-") and token != "-"
+  defp negative_number?(token), do: Regex.match?(~r/^-\d+(\.\d+)?$/, token)
 
   defp validate_num_args(num_args_values, options) do
     Enum.reduce_while(num_args_values, :ok, fn {name, values}, _acc ->

--- a/test/cheer_test.exs
+++ b/test/cheer_test.exs
@@ -2774,4 +2774,57 @@ defmodule CheerTest do
       end
     end
   end
+
+  # -- allow_hyphen_values and negative numbers (#73, #64) ---------------------
+
+  defmodule TestHyphen do
+    use Cheer.Command
+
+    command "hy" do
+      option(:range, type: :integer, num_args: 2)
+      option(:coords, type: :string, num_args: 2, allow_hyphen_values: true)
+      option(:pattern, type: :string, allow_hyphen_values: true)
+      option(:plain, type: :string)
+      option(:verbose, type: :boolean)
+    end
+
+    @impl Cheer.Command
+    def run(args, _raw), do: {:ok, args}
+  end
+
+  describe "negative numbers in num_args (#64)" do
+    test "negative numbers are collected without allow_hyphen_values" do
+      assert {:ok, %{range: [-5, 5]}} = Cheer.run(TestHyphen, ["--range", "-5", "5"])
+    end
+
+    test "a non-numeric flag still stops collection without allow_hyphen_values" do
+      output = capture_io(fn -> Cheer.run(TestHyphen, ["--range", "1", "--verbose"]) end)
+      assert output =~ "--range expects 2 value(s)"
+    end
+  end
+
+  describe "allow_hyphen_values (#73)" do
+    test "num_args option collects hyphen-prefixed values" do
+      assert {:ok, %{coords: ["-a", "-b"]}} = Cheer.run(TestHyphen, ["--coords", "-a", "-b"])
+    end
+
+    test "single-value option accepts a hyphen-prefixed value" do
+      assert {:ok, %{pattern: "-foo"}} = Cheer.run(TestHyphen, ["--pattern", "-foo"])
+      assert {:ok, %{pattern: "--bar"}} = Cheer.run(TestHyphen, ["--pattern", "--bar"])
+    end
+
+    test "single-value option accepts a hyphen-prefixed value in inline form" do
+      assert {:ok, %{pattern: "-x"}} = Cheer.run(TestHyphen, ["--pattern=-x"])
+    end
+
+    test "single-value option takes exactly one value and leaves following flags" do
+      assert {:ok, %{pattern: "x", verbose: true}} =
+               Cheer.run(TestHyphen, ["--pattern", "x", "--verbose"])
+    end
+
+    test "an option without allow_hyphen_values still rejects a hyphen value" do
+      output = capture_io(fn -> Cheer.run(TestHyphen, ["--plain", "-foo"]) end)
+      assert output =~ "unknown option"
+    end
+  end
 end


### PR DESCRIPTION
Closes #64. Closes #73.

## #64 negative numbers in num_args (always on)

`num_args` collection stopped at any `-`-prefixed token, so `--range -5 5` failed. Negative numbers are now always collected (`[-5, 5]`), since a negative number is unambiguously a value in a num_args context.

## #73 `:allow_hyphen_values`

Opt-in flag to accept a value that starts with `-` beyond negative numbers:

```elixir
option :pattern, type: :string, allow_hyphen_values: true          # --pattern -v -> "-v"
option :range, type: :integer, num_args: 2, allow_hyphen_values: true  # --range -a -b -> ["-a","-b"]
```

Covers both surfaces (the closed drive-by version only did num_args):
- **Single-value options** are pulled out of argv before OptionParser (which would otherwise read a `-`-prefixed value as a flag), consuming exactly the next token, so a following flag still parses (`--pattern x --verbose`). Inline form `--pattern=-x` also works.
- **num_args options** collect hyphen-leading tokens up to the declared count.

Without the flag, only negative numbers are accepted; `--plain -foo` still errors.

Verified matrix in tests; guide section added to `options.md`; DSL docs updated. 260 tests green.