### PR TITLE
feat: suggest closest option name for an unknown flag

### DIFF
--- a/lib/cheer/router.ex
+++ b/lib/cheer/router.ex
@@ -244,7 +244,7 @@ defmodule Cheer.Router do
       OptionParser.parse(argv, strict: option_parser_opts, aliases: option_aliases)
 
     if invalid != [] do
-      print_invalid_options_error(command, invalid, opts)
+      print_invalid_options_error(command, invalid, opts, all_options)
       :handled
     else
       parsed_map = build_parsed_map(parsed, all_options)
@@ -351,7 +351,7 @@ defmodule Cheer.Router do
       OptionParser.parse_head(argv, strict: option_parser_opts, aliases: option_aliases)
 
     if invalid != [] do
-      print_invalid_options_error(command, invalid, opts)
+      print_invalid_options_error(command, invalid, opts, all_options)
       :handled
     else
       parsed_map = build_parsed_map(parsed, all_options)
@@ -1075,10 +1075,30 @@ defmodule Cheer.Router do
     Cheer.Help.print(command, opts)
   end
 
-  defp print_invalid_options_error(command, invalid, opts) do
+  defp print_invalid_options_error(command, invalid, opts, all_options) do
     flags = Enum.map_join(invalid, ", ", fn {flag, _} -> flag end)
     IO.puts("error: unknown option(s): #{flags}")
+
+    candidates = option_name_candidates(all_options)
+
+    Enum.each(invalid, fn {flag, _value} ->
+      # Exclude an exact match so a known option given a bad value (OptionParser
+      # reports it in `invalid` too) does not suggest the flag the user typed.
+      with "--" <> name <- flag,
+           suggestion when not is_nil(suggestion) <- suggest(name, candidates -- [name]) do
+        IO.puts("\n  Did you mean '--#{suggestion}'?")
+      else
+        _ -> :ok
+      end
+    end)
+
     IO.puts("")
     Cheer.Help.print(command, opts)
+  end
+
+  defp option_name_candidates(all_options) do
+    Enum.flat_map(all_options, fn {name, opts} ->
+      [flag_string(name) | Enum.map(Keyword.get(opts, :aliases, []), &flag_string/1)]
+    end)
   end
 end

--- a/test/cheer_test.exs
+++ b/test/cheer_test.exs
@@ -418,6 +418,43 @@ defmodule CheerTest do
     end
   end
 
+  defmodule TestSuggest do
+    use Cheer.Command
+
+    command "sg" do
+      option(:color, type: :string, aliases: [:colour])
+      option(:port, type: :integer)
+    end
+
+    @impl Cheer.Command
+    def run(args, _raw), do: {:ok, args}
+  end
+
+  describe "unknown-flag suggestions (#71)" do
+    test "suggests the closest option for a typo'd flag" do
+      out = capture_io(fn -> Cheer.run(TestSuggest, ["--colr", "red"]) end)
+      assert out =~ "unknown option(s): --colr"
+      assert out =~ "Did you mean '--color'?"
+    end
+
+    test "suggests an alias when it is the closest match" do
+      out = capture_io(fn -> Cheer.run(TestSuggest, ["--colour-", "red"]) end)
+      assert out =~ "Did you mean '--colour'?"
+    end
+
+    test "prints no suggestion when nothing is close" do
+      out = capture_io(fn -> Cheer.run(TestSuggest, ["--zzzzzz"]) end)
+      assert out =~ "unknown option(s): --zzzzzz"
+      refute out =~ "Did you mean"
+    end
+
+    test "a known option given a bad value does not suggest itself" do
+      out = capture_io(fn -> Cheer.run(TestSuggest, ["--port", "abc"]) end)
+      assert out =~ "unknown option(s): --port"
+      refute out =~ "Did you mean"
+    end
+  end
+
   # -- Environment variable fallback -------------------------------------------
 
   defmodule TestEnvVar do


### PR DESCRIPTION
Closes #71.

## Summary

Cheer already prints "Did you mean 'x'?" for an unknown subcommand (`suggest/2`), but an unknown flag got no suggestion. Wire the existing Jaro-distance `suggest/2` into the invalid-options path, matching against declared option long-names and their aliases (kebab-cased).

## Guard against the drive-by's bug

OptionParser also reports a *known* option given a bad-typed value in the same `invalid` list (e.g. `--port abc` for an integer option). A naive version suggests the very flag the user typed (`Did you mean '--port'?`). This implementation excludes an exact match from the candidates, so a bad-value case produces no bogus self-suggestion, while `--colr` still suggests `--color`.

## Plan

- [ ] Thread declared options into `print_invalid_options_error`.
- [ ] Suggest the closest declared flag/alias, excluding an exact match.
- [ ] Tests: typo suggests, alias suggests, nothing-close prints nothing, bad-value does not self-suggest.