### PR TITLE
feat: value_delimiter to split a single value into a list

### DIFF
--- a/docs/guides/options.md
+++ b/docs/guides/options.md
@@ -91,6 +91,23 @@ A single-value option consumes exactly the next token as its value, so a
 following flag is still parsed normally (`--pattern x --verbose`). With
 `:num_args`, collection consumes hyphen-leading tokens up to the declared count.
 
+## Delimited values (`:value_delimiter`)
+
+`:value_delimiter` splits one value on a string into a list:
+
+```elixir
+option :tags, type: :string, value_delimiter: ","
+# --tags a,b,c  ->  args[:tags] == ["a", "b", "c"]
+
+option :ids, type: :integer, value_delimiter: ","
+# --ids 1,2,3   ->  args[:ids] == [1, 2, 3]
+```
+
+Each element is coerced to the option's `:type` and validated against
+`:choices`. A string `:default` is split the same way, and it combines with
+`:multi` (each occurrence is split and the results flattened). This differs
+from `:num_args`, which reads several separate tokens after one flag.
+
 ## Aliases (long-form)
 
 ```elixir

--- a/lib/cheer/command/dsl.ex
+++ b/lib/cheer/command/dsl.ex
@@ -202,6 +202,10 @@ defmodule Cheer.Command.DSL do
     * `:allow_hyphen_values` - `true` to accept a value that starts with `-`, such
       as `--pattern -v` or `--range -a -b` (with `num_args`). Without it, only
       negative numbers are accepted as hyphen-leading values.
+    * `:value_delimiter` - split a single value on this string into a list, e.g.
+      `value_delimiter: ","` makes `--tags a,b,c` yield `["a", "b", "c"]`. Each
+      element is coerced to `:type` and checked against `:choices`. Combines with
+      `:multi` (each occurrence is split and the results flattened).
     * `:env` - environment variable name to read as fallback
     * `:choices` - list of allowed values
     * `:help` - help text shown in `--help`

--- a/lib/cheer/router.ex
+++ b/lib/cheer/router.ex
@@ -253,6 +253,7 @@ defmodule Cheer.Router do
       args = Map.merge(args, parsed_map)
       args = Map.merge(args, num_args_values)
       args = Map.merge(args, hyphen_values)
+      args = apply_value_delimiters(args, all_options)
 
       {declared_positional, rest_args} = Enum.split(positional, length(meta.arguments))
 
@@ -582,6 +583,42 @@ defmodule Cheer.Router do
     end)
   end
 
+  # -- Value delimiter --
+
+  # Split value_delimiter options into a list and coerce each element. Runs after
+  # all value sources are merged, so it covers user-supplied values, env
+  # fallbacks, and string defaults uniformly. A :multi value (already a list) has
+  # each occurrence split and the result flattened.
+  defp apply_value_delimiters(args, options) do
+    Enum.reduce(options, args, fn {name, opts}, acc ->
+      case Keyword.get(opts, :value_delimiter) do
+        nil ->
+          acc
+
+        delim ->
+          case Map.fetch(acc, name) do
+            {:ok, value} -> Map.put(acc, name, split_delimited(value, delim, opts))
+            :error -> acc
+          end
+      end
+    end)
+  end
+
+  defp split_delimited(value, delim, opts) when is_binary(value) do
+    value |> String.split(delim) |> Enum.map(&coerce_arg(&1, opts))
+  end
+
+  defp split_delimited(values, delim, opts) when is_list(values) do
+    values
+    |> Enum.flat_map(fn
+      v when is_binary(v) -> String.split(v, delim)
+      v -> [v]
+    end)
+    |> Enum.map(&coerce_arg(&1, opts))
+  end
+
+  defp split_delimited(value, _delim, _opts), do: value
+
   defp coerce_env(value, :integer) do
     case Integer.parse(value) do
       {n, ""} -> n
@@ -635,7 +672,10 @@ defmodule Cheer.Router do
         :ok
 
       choices ->
-        if to_string(value) in Enum.map(choices, &to_string/1) do
+        allowed = Enum.map(choices, &to_string/1)
+        values = if is_list(value), do: value, else: [value]
+
+        if Enum.all?(values, &(to_string(&1) in allowed)) do
           :ok
         else
           {:error, "--#{name} must be one of: #{Enum.join(choices, ", ")}"}
@@ -943,7 +983,7 @@ defmodule Cheer.Router do
   defp build_option_parser_spec(options) do
     spec =
       Enum.map(options, fn {name, opts} ->
-        type = Keyword.get(opts, :type, :string)
+        type = parser_type(opts)
 
         if Keyword.get(opts, :multi, false) do
           {name, [type, :keep]}
@@ -958,7 +998,7 @@ defmodule Cheer.Router do
       options
       |> Enum.filter(fn {_name, opts} -> Keyword.has_key?(opts, :aliases) end)
       |> Enum.flat_map(fn {_name, opts} ->
-        type = Keyword.get(opts, :type, :string)
+        type = parser_type(opts)
 
         type_spec =
           if Keyword.get(opts, :multi, false), do: [type, :keep], else: type
@@ -972,6 +1012,17 @@ defmodule Cheer.Router do
       |> Enum.map(fn {name, opts} -> {Keyword.fetch!(opts, :short), name} end)
 
     {spec ++ alias_specs, aliases}
+  end
+
+  # value_delimiter options are parsed as raw strings so OptionParser does not
+  # try to coerce the whole "a,b,c" token; splitting and per-element coercion
+  # happen afterward in apply_value_delimiters/2.
+  defp parser_type(opts) do
+    if Keyword.has_key?(opts, :value_delimiter) do
+      :string
+    else
+      Keyword.get(opts, :type, :string)
+    end
   end
 
   defp build_parsed_map(parsed, options) do

--- a/test/cheer_test.exs
+++ b/test/cheer_test.exs
@@ -3025,4 +3025,54 @@ defmodule CheerTest do
       assert output =~ "unknown option"
     end
   end
+
+  # -- value_delimiter (#70) ---------------------------------------------------
+
+  defmodule TestDelimiter do
+    use Cheer.Command
+
+    command "dl" do
+      option(:tags, type: :string, value_delimiter: ",")
+      option(:ids, type: :integer, value_delimiter: ",")
+      option(:colors, type: :string, value_delimiter: ",", choices: ["red", "green", "blue"])
+      option(:groups, type: :string, multi: true, value_delimiter: ",")
+      option(:def, type: :string, value_delimiter: ",", default: "x,y")
+    end
+
+    @impl Cheer.Command
+    def run(args, _raw), do: {:ok, args}
+  end
+
+  describe "value_delimiter (#70)" do
+    test "splits a single value into a list" do
+      assert {:ok, %{tags: ["a", "b", "c"]}} = Cheer.run(TestDelimiter, ["--tags", "a,b,c"])
+    end
+
+    test "coerces each element to the option type" do
+      assert {:ok, %{ids: [1, 2, 3]}} = Cheer.run(TestDelimiter, ["--ids", "1,2,3"])
+    end
+
+    test "works with the inline --flag=value form" do
+      assert {:ok, %{tags: ["x", "y"]}} = Cheer.run(TestDelimiter, ["--tags=x,y"])
+    end
+
+    test "accepts a delimited value whose elements are all valid choices" do
+      assert {:ok, %{colors: ["red", "green"]}} =
+               Cheer.run(TestDelimiter, ["--colors", "red,green"])
+    end
+
+    test "rejects a delimited value with an element outside the choices" do
+      output = capture_io(fn -> Cheer.run(TestDelimiter, ["--colors", "red,purple"]) end)
+      assert output =~ "must be one of"
+    end
+
+    test "combines with :multi, flattening each split occurrence" do
+      assert {:ok, %{groups: ["a", "b", "c", "d"]}} =
+               Cheer.run(TestDelimiter, ["--groups", "a,b", "--groups", "c,d"])
+    end
+
+    test "splits a string default the same way" do
+      assert {:ok, %{def: ["x", "y"]}} = Cheer.run(TestDelimiter, [])
+    end
+  end
 end


### PR DESCRIPTION
Closes #70.

Adds `:value_delimiter` so a single value splits into a list:

```elixir
option :tags, type: :string, value_delimiter: ","      # --tags a,b,c -> ["a","b","c"]
option :ids, type: :integer, value_delimiter: ","      # --ids 1,2,3  -> [1,2,3]
```

## Implementation

The option is parsed as a raw string (so OptionParser does not fail coercing `"1,2,3"` as an integer), then split and each element coerced to `:type` in a post-merge pass. Running after all value sources are merged means user-supplied values, env fallbacks, and string defaults are all handled uniformly.

## Handles the interactions a naive version misses

The closed drive-by version rejected valid choices, ignored defaults, and skipped num_args. This one:
- validates `:choices` **per element** (a fully valid delimited value is accepted, not rejected)
- splits a string `:default` the same way
- combines with `:multi`, flattening each split occurrence

Verified matrix in tests; DSL and guide docs added. 288 tests green.