### PR TITLE
feat: :parse custom value parsers

### DIFF
--- a/docs/guides/validation.md
+++ b/docs/guides/validation.md
@@ -52,6 +52,33 @@ end
 You can declare multiple `validate` blocks per command. They run in
 declaration order; the first `{:error, ...}` halts the pipeline.
 
+## Transforming values (`:parse`)
+
+`:validate` checks a value but leaves it unchanged. `:parse` transforms it into a
+domain type, so `run/2` receives an atom, a `Date`, or a struct instead of a
+string:
+
+```elixir
+option :mode, type: :string,
+  parse: fn
+    "r" -> {:ok, :read}
+    "w" -> {:ok, :write}
+    _ -> {:error, "must be r or w"}
+  end
+
+argument :on, type: :string,
+  parse: fn s ->
+    case Date.from_iso8601(s) do
+      {:ok, d} -> {:ok, d}
+      {:error, _} -> {:error, "expected YYYY-MM-DD"}
+    end
+  end
+```
+
+It runs after `:type` coercion and `:value_delimiter` splitting and before
+`:choices` and `:validate`. An `{:error, msg}` is a usage failure. For a list
+value (`:multi`, `:num_args`, `:value_delimiter`) it is applied to each element.
+
 ## Order of evaluation
 
 For a single invocation, validation runs in this order:
@@ -59,12 +86,13 @@ For a single invocation, validation runs in this order:
 1. Type coercion (automatic, based on `:type`).
 2. Defaults and env var fallback.
 3. Required-argument and required-option checks.
-4. Choices (`:choices`).
-5. Per-param `:validate` functions.
-6. Cross-param validators (`validate fn args -> ... end`).
-7. Conditional-required (`:required_if`, `:required_unless`).
-8. Per-option constraints (`:conflicts_with`, `:requires`).
-9. Group constraints (`mutually_exclusive`, `co_occurring`).
+4. `:parse` transforms.
+5. Choices (`:choices`).
+6. Per-param `:validate` functions.
+7. Cross-param validators (`validate fn args -> ... end`).
+8. Conditional-required (`:required_if`, `:required_unless`).
+9. Per-option constraints (`:conflicts_with`, `:requires`).
+10. Group constraints (`mutually_exclusive`, `co_occurring`).
 
 The first failure halts; your `run/2` is only called if everything passes.
 

--- a/lib/cheer/command.ex
+++ b/lib/cheer/command.ex
@@ -60,6 +60,7 @@ defmodule Cheer.Command do
       Module.register_attribute(__MODULE__, :cheer_options, accumulate: true)
       Module.register_attribute(__MODULE__, :cheer_subcommands, accumulate: true)
       Module.register_attribute(__MODULE__, :cheer_has_validate, accumulate: true)
+      Module.register_attribute(__MODULE__, :cheer_has_parse, accumulate: true)
       Module.register_attribute(__MODULE__, :cheer_groups, accumulate: true)
 
       # Counters for indexed function generation are managed at macro-expansion

--- a/lib/cheer/command/compiler.ex
+++ b/lib/cheer/command/compiler.ex
@@ -30,6 +30,7 @@ defmodule Cheer.Command.Compiler do
     options = Module.get_attribute(env.module, :cheer_options) |> Enum.reverse()
     subcommands = Module.get_attribute(env.module, :cheer_subcommands) |> Enum.reverse()
     has_validate = Module.get_attribute(env.module, :cheer_has_validate)
+    has_parse = Module.get_attribute(env.module, :cheer_has_parse)
     # Hook counters are incremented at macro-expansion time (see
     # Cheer.Command.DSL.next_hook_index/2). A command that declares no hooks of a
     # kind never writes the attribute, so default nil to 0.
@@ -69,38 +70,9 @@ defmodule Cheer.Command.Compiler do
     # Build groups map: %{group_name => %{opts: [...], members: [...]}}
     groups = build_groups(raw_groups)
 
-    # Options: merge validate fns from generated functions
-    options_expr =
-      if has_validate == [] do
-        Macro.escape(options)
-      else
-        quote do
-          Enum.map(unquote(Macro.escape(options)), fn {n, o} ->
-            if n in unquote(has_validate) do
-              fname = :"__cheer_validate_#{n}__"
-              {n, Keyword.put(o, :validate, &apply(__MODULE__, fname, [&1]))}
-            else
-              {n, o}
-            end
-          end)
-        end
-      end
-
-    arguments_expr =
-      if has_validate == [] do
-        Macro.escape(arguments)
-      else
-        quote do
-          Enum.map(unquote(Macro.escape(arguments)), fn {n, o} ->
-            if n in unquote(has_validate) do
-              fname = :"__cheer_validate_#{n}__"
-              {n, Keyword.put(o, :validate, &apply(__MODULE__, fname, [&1]))}
-            else
-              {n, o}
-            end
-          end)
-        end
-      end
+    # Merge the generated :validate / :parse accessor fns back into the param opts.
+    options_expr = merge_accessors(options, has_validate, has_parse)
+    arguments_expr = merge_accessors(arguments, has_validate, has_parse)
 
     validators_expr = make_indexed_fns(:__cheer_cross_validate__, validator_count)
     before_run_expr = make_indexed_fns(:__cheer_before_run__, before_run_count)
@@ -137,6 +109,29 @@ defmodule Cheer.Command.Compiler do
           persistent_before_run: unquote(persistent_before_expr),
           groups: unquote(Macro.escape(groups))
         }
+      end
+    end
+  end
+
+  # Reattach generated :validate / :parse accessor fns to the {name, opts} list.
+  defp merge_accessors(params, has_validate, has_parse) do
+    if has_validate == [] and has_parse == [] do
+      Macro.escape(params)
+    else
+      quote do
+        Enum.map(unquote(Macro.escape(params)), fn {n, o} ->
+          o =
+            if n in unquote(has_validate),
+              do: Keyword.put(o, :validate, &apply(__MODULE__, :"__cheer_validate_#{n}__", [&1])),
+              else: o
+
+          o =
+            if n in unquote(has_parse),
+              do: Keyword.put(o, :parse, &apply(__MODULE__, :"__cheer_parse_#{n}__", [&1])),
+              else: o
+
+          {n, o}
+        end)
       end
     end
   end

--- a/lib/cheer/command/dsl.ex
+++ b/lib/cheer/command/dsl.ex
@@ -165,22 +165,37 @@ defmodule Cheer.Command.DSL do
     * `:hide` - `true` to hide from help output
     * `:display_order` - integer controlling position in help (lower first)
     * `:validate` - `fn value -> :ok | {:error, msg} end`
+    * `:parse` - `fn value -> {:ok, parsed} | {:error, msg} end` to transform the
+      value into a domain type (runs after coercion, before `:validate`)
   """
   defmacro argument(name, opts \\ []) do
-    {validate_ast, clean_opts} = Keyword.pop(opts, :validate)
+    {validate_ast, opts} = Keyword.pop(opts, :validate)
+    {parse_ast, clean_opts} = Keyword.pop(opts, :parse)
 
-    if validate_ast do
-      fname = :"__cheer_validate_#{name}__"
+    quote do
+      @cheer_arguments {unquote(name), unquote(clean_opts)}
+      unquote(accessor_fn(:validate, name, validate_ast))
+      unquote(accessor_fn(:parse, name, parse_ast))
+    end
+  end
 
-      quote do
-        @cheer_arguments {unquote(name), unquote(clean_opts)}
-        @cheer_has_validate unquote(name)
-        def unquote(fname)(val), do: unquote(validate_ast).(val)
-      end
-    else
-      quote do
-        @cheer_arguments {unquote(name), unquote(clean_opts)}
-      end
+  # Anonymous functions in DSL opts (:validate, :parse) cannot be Macro.escape'd
+  # into module attributes, so generate a named accessor and record the name; the
+  # compiler reattaches the fn into the param opts. Returns nil (a no-op in the
+  # surrounding quote block) when the option was not given.
+  defp accessor_fn(_kind, _name, nil), do: nil
+
+  defp accessor_fn(:validate, name, ast) do
+    quote do
+      @cheer_has_validate unquote(name)
+      def unquote(:"__cheer_validate_#{name}__")(val), do: unquote(ast).(val)
+    end
+  end
+
+  defp accessor_fn(:parse, name, ast) do
+    quote do
+      @cheer_has_parse unquote(name)
+      def unquote(:"__cheer_parse_#{name}__")(val), do: unquote(ast).(val)
     end
   end
 
@@ -206,6 +221,11 @@ defmodule Cheer.Command.DSL do
       `value_delimiter: ","` makes `--tags a,b,c` yield `["a", "b", "c"]`. Each
       element is coerced to `:type` and checked against `:choices`. Combines with
       `:multi` (each occurrence is split and the results flattened).
+    * `:parse` - `fn value -> {:ok, parsed} | {:error, msg} end` to transform the
+      value into a domain type (an atom, a `Date`, a struct). Runs after `:type`
+      coercion and `:value_delimiter` splitting, before `:choices` and `:validate`.
+      For a list value (`:multi`, `:num_args`, `:value_delimiter`) it is applied to
+      each element.
     * `:env` - environment variable name to read as fallback
     * `:choices` - list of allowed values
     * `:help` - help text shown in `--help`
@@ -229,25 +249,13 @@ defmodule Cheer.Command.DSL do
   Extra positional arguments after `--` are collected into `args[:rest]`.
   """
   defmacro option(name, opts \\ []) do
-    {validate_ast, clean_opts} = Keyword.pop(opts, :validate)
-
-    base =
-      if validate_ast do
-        fname = :"__cheer_validate_#{name}__"
-
-        quote do
-          @cheer_options {unquote(name), unquote(clean_opts)}
-          @cheer_has_validate unquote(name)
-          def unquote(fname)(val), do: unquote(validate_ast).(val)
-        end
-      else
-        quote do
-          @cheer_options {unquote(name), unquote(clean_opts)}
-        end
-      end
+    {validate_ast, opts} = Keyword.pop(opts, :validate)
+    {parse_ast, clean_opts} = Keyword.pop(opts, :parse)
 
     quote do
-      unquote(base)
+      @cheer_options {unquote(name), unquote(clean_opts)}
+      unquote(accessor_fn(:validate, name, validate_ast))
+      unquote(accessor_fn(:parse, name, parse_ast))
 
       # If inside a group block, register this option in the group
       if @cheer_current_group do

--- a/lib/cheer/router.ex
+++ b/lib/cheer/router.ex
@@ -308,7 +308,8 @@ defmodule Cheer.Router do
           :handled
 
         true ->
-          with :ok <- validate_num_args(num_args_values, all_options),
+          with {:ok, args} <- apply_parsers(args, all_options ++ meta.arguments),
+               :ok <- validate_num_args(num_args_values, all_options),
                :ok <- validate_conditional_required(args, all_options, provided),
                :ok <- validate_constraints(all_options, provided),
                :ok <- validate_groups(provided, Map.get(meta, :groups, %{})),
@@ -377,7 +378,8 @@ defmodule Cheer.Router do
           :handled
 
         true ->
-          with :ok <- validate_num_args(num_args_values, all_options),
+          with {:ok, args} <- apply_parsers(args, all_options ++ meta.arguments),
+               :ok <- validate_num_args(num_args_values, all_options),
                :ok <- validate_conditional_required(args, all_options, provided),
                :ok <- validate_constraints(all_options, provided),
                :ok <- validate_groups(provided, Map.get(meta, :groups, %{})),
@@ -648,6 +650,40 @@ defmodule Cheer.Router do
   defp coerce_env(value, _), do: value
 
   # -- Per-param validation --
+
+  # -- Custom parsers (:parse) --
+
+  # Apply each param's :parse fn to its value, transforming it into a domain
+  # value. Runs before validation so :choices/:validate see the parsed value. A
+  # list value (multi, num_args, value_delimiter) is parsed element-wise.
+  defp apply_parsers(args, params) do
+    Enum.reduce_while(params, {:ok, args}, fn {name, opts}, {:ok, acc} ->
+      with fun when is_function(fun, 1) <- Keyword.get(opts, :parse),
+           {:ok, value} <- Map.fetch(acc, name) do
+        case apply_parse_value(fun, value) do
+          {:ok, parsed} -> {:cont, {:ok, Map.put(acc, name, parsed)}}
+          {:error, msg} -> {:halt, {:error, "--#{flag_string(name)}: #{msg}"}}
+        end
+      else
+        _ -> {:cont, {:ok, acc}}
+      end
+    end)
+  end
+
+  defp apply_parse_value(fun, values) when is_list(values) do
+    Enum.reduce_while(values, {:ok, []}, fn v, {:ok, acc} ->
+      case fun.(v) do
+        {:ok, parsed} -> {:cont, {:ok, [parsed | acc]}}
+        {:error, _} = err -> {:halt, err}
+      end
+    end)
+    |> case do
+      {:ok, list} -> {:ok, Enum.reverse(list)}
+      err -> err
+    end
+  end
+
+  defp apply_parse_value(fun, value), do: fun.(value)
 
   defp validate_params(args, options) do
     Enum.reduce_while(options, :ok, fn {name, opts}, _acc ->

--- a/test/cheer_test.exs
+++ b/test/cheer_test.exs
@@ -3075,4 +3075,57 @@ defmodule CheerTest do
       assert {:ok, %{def: ["x", "y"]}} = Cheer.run(TestDelimiter, [])
     end
   end
+
+  # -- Custom value parsers (:parse) (#72) -------------------------------------
+
+  defmodule TestParse do
+    use Cheer.Command
+
+    command "pr" do
+      option(:mode,
+        type: :string,
+        parse: fn
+          "r" -> {:ok, :read}
+          "w" -> {:ok, :write}
+          _ -> {:error, "must be r or w"}
+        end
+      )
+
+      option(:port, type: :integer, parse: fn n -> {:ok, n * 2} end)
+
+      option(:tags,
+        type: :string,
+        value_delimiter: ",",
+        parse: fn s -> {:ok, String.upcase(s)} end
+      )
+
+      argument(:name, type: :string, required: false, parse: fn s -> {:ok, String.to_atom(s)} end)
+    end
+
+    @impl Cheer.Command
+    def run(args, _raw), do: {:ok, args}
+  end
+
+  describe "custom value parsers (:parse) (#72)" do
+    test "transforms an option value into a domain value" do
+      assert {:ok, %{mode: :read}} = Cheer.run(TestParse, ["--mode", "r"])
+    end
+
+    test "an :error result is a usage failure with the flag name and message" do
+      output = capture_io(fn -> Cheer.run(TestParse, ["--mode", "x"]) end)
+      assert output =~ "--mode: must be r or w"
+    end
+
+    test "runs after built-in type coercion" do
+      assert {:ok, %{port: 20}} = Cheer.run(TestParse, ["--port", "10"])
+    end
+
+    test "is applied element-wise to a delimited list" do
+      assert {:ok, %{tags: ["A", "B"]}} = Cheer.run(TestParse, ["--tags", "a,b"])
+    end
+
+    test "transforms an argument value" do
+      assert {:ok, %{name: :foo}} = Cheer.run(TestParse, ["foo"])
+    end
+  end
 end


### PR DESCRIPTION
Closes #72.

Adds `:parse` to transform an option or argument value into a domain type:

```elixir
option :mode, type: :string, parse: fn
  "r" -> {:ok, :read}
  "w" -> {:ok, :write}
  _ -> {:error, "must be r or w"}
end
# --mode r  ->  args[:mode] == :read
```

## Contract

`fn value -> {:ok, parsed} | {:error, msg}`. Runs after `:type` coercion and `:value_delimiter` splitting, before `:choices` and `:validate`. An `{:error, msg}` is a usage failure (`--mode: must be r or w`). Applied element-wise to list values (`:multi`, `:num_args`, `:value_delimiter`). Works on options, arguments, and env fallbacks.

## Implementation

Like `:validate`, an anonymous `:parse` fn can't be escaped into a module attribute, so it uses the same generated-named-accessor pattern. Refactored the DSL to share an `accessor_fn/3` helper across `:validate` and `:parse`, and the compiler to share `merge_accessors/3` that reattaches both. Existing `:validate` behavior is unchanged (full suite green).

Verified matrix in tests (transform, error path, after-coercion, element-wise, argument); DSL and validation-guide docs added. 293 tests green.