### PR TITLE
feat: Cheer.MixTask helper for building Mix tasks from Cheer commands

### DIFF
--- a/docs/cookbook/mix_task.md
+++ b/docs/cookbook/mix_task.md
@@ -6,35 +6,14 @@ like a standalone CLI. No framework changes are needed.
 
 Full runnable project: [`examples/mix_task/`](https://github.com/joshrotenberg/cheer/tree/main/examples/mix_task).
 
-## The key idea
-
-A Mix task is a module named `Mix.Tasks.<Name>` that does `use Mix.Task` and
-implements `run/1`, receiving the raw argv list. A Cheer command does
-`use Cheer.Command` and implements `run/2`, receiving parsed args. These do not
-collide: `run/1` and `run/2` have different arities, so one module can be both.
-
-The Mix entry point (`run/1`) delegates to `Cheer.run/3`, which does the
-parsing, validation, and help rendering and then calls your `run/2`.
-
 ## The task
+
+`use Cheer.MixTask` combines `use Mix.Task` and `use Cheer.Command` and generates
+the Mix `run/1` entry point. Declare the command and implement the leaf `run/2`:
 
 ```elixir
 defmodule Mix.Tasks.Greet do
-  @shortdoc "Greet someone with style"
-
-  @moduledoc """
-  #{@shortdoc}
-
-  ## Examples
-
-      mix greet world
-      mix greet world --loud --times 3
-      GREET_GREETING=Hey mix greet Ada
-      mix greet --help
-  """
-
-  use Mix.Task
-  use Cheer.Command
+  use Cheer.MixTask
 
   command "greet" do
     about "Greet someone with style"
@@ -51,27 +30,44 @@ defmodule Mix.Tasks.Greet do
       help: "Repeat the greeting"
   end
 
-  # Mix entry point. Delegate to Cheer, then translate a usage failure into the
-  # Mix exit idiom.
-  @impl Mix.Task
-  def run(argv) do
-    case Cheer.run(__MODULE__, argv, prog: "mix greet") do
-      {:error, :usage} -> exit({:shutdown, 2})
-      other -> other
-    end
-  end
-
-  # Cheer leaf handler. Runs once argv has parsed and validated cleanly.
   @impl Cheer.Command
   def run(%{name: name} = args, _raw) do
     greeting = "#{args[:greeting]}, #{name}!"
     greeting = if args[:loud], do: String.upcase(greeting), else: greeting
 
     for _ <- 1..args[:times] do
-      IO.puts(greeting)
+      Mix.shell().info(greeting)
     end
 
     :ok
+  end
+end
+```
+
+Then `mix greet world --loud` parses, validates, and renders help exactly like a
+standalone CLI.
+
+## What the helper generates
+
+`use Cheer.MixTask` gives you:
+
+- a `run/1` Mix entry point that dispatches argv through the command with
+  `Cheer.run/3`, using `mix greet` as the program name in help and usage output;
+- a `{:error, :usage}` to `exit({:shutdown, 2})` translation, the Mix idiom for a
+  nonzero exit;
+- `@shortdoc` defaulted to the command's `about` text, so `mix help` lists the task.
+
+If you prefer to wire it by hand (or need to override `run/1` for setup), the
+manual equivalent is a plain module that does `use Mix.Task` and `use Cheer.Command`
+(they coexist because `run/1` and `run/2` have different arities) with a `run/1`
+that delegates:
+
+```elixir
+@impl Mix.Task
+def run(argv) do
+  case Cheer.run(__MODULE__, argv, prog: "mix greet") do
+    {:error, :usage} -> exit({:shutdown, 2})
+    other -> other
   end
 end
 ```
@@ -107,15 +103,15 @@ standard Mix mechanism, so the task lists and documents itself like any other.
 
 ## Signaling failure
 
-Return `{:error, :usage}` from a usage failure into a nonzero exit code with
-`exit({:shutdown, 2})`. That is the Mix idiom: Mix catches this exit and halts
-with the given code without a crash report.
+The helper translates a `{:error, :usage}` result into `exit({:shutdown, 2})`,
+the Mix idiom: Mix catches this exit and halts with the given code without a
+crash report.
 
 Do **not** use `Cheer.main/3` inside a Mix task. `main/3` calls `System.halt`,
 which hard-kills the VM immediately: it skips Mix's own cleanup and is wrong
-inside `mix`, CI, and umbrella projects. `Cheer.run/3` exists as the separate
-primitive precisely so callers can decide how to exit. `main/3` is for escript
-entry points, where halting the VM is the whole point.
+inside `mix`, CI, and umbrella projects. The helper uses `Cheer.run/3` for
+exactly this reason. `main/3` is for escript entry points, where halting the VM
+is the whole point.
 
 ## Starting the application
 
@@ -131,17 +127,18 @@ end
 ```
 
 `Application.ensure_all_started/1` works too when you only need a specific
-application.
+application. If you would rather start the app before argv is even parsed,
+override the generated `run/1` and call `Cheer.run/3` yourself.
 
 ## What it shows
 
-- **One module, two behaviours** -- `use Mix.Task` and `use Cheer.Command`
-  coexist because `run/1` and `run/2` do not collide.
-- **`prog: "mix greet"`** -- so the usage line reads as the Mix invocation, not
+- **`use Cheer.MixTask`** -- one line that makes a Cheer command a Mix task,
+  generating the `run/1` entry point.
+- **`mix greet` program name** -- the usage line reads as the Mix invocation, not
   a bare command name.
-- **Exit codes** -- `exit({:shutdown, 2})` translates a Cheer usage failure into
-  a conventional nonzero exit.
-- **Mix help integration** -- `@shortdoc` / `@moduledoc` drive `mix help`.
+- **Exit codes** -- a usage failure becomes `exit({:shutdown, 2})`, a conventional
+  nonzero exit.
+- **Mix help integration** -- `@shortdoc` defaults to the command's `about`.
 - **The `main/3` caveat** -- never `System.halt` from inside a Mix task.
 
 ## See also

--- a/examples/mix_task/lib/mix/tasks/greet.ex
+++ b/examples/mix_task/lib/mix/tasks/greet.ex
@@ -1,11 +1,10 @@
 defmodule Mix.Tasks.Greet do
-  @shortdoc "Greet someone with style"
-
   @moduledoc """
-  #{@shortdoc}
+  Greet someone with style.
 
-  A single Cheer command driving a Mix task. Because `Mix.Task` needs `run/1`
-  and `Cheer.Command` needs `run/2`, one module can be both.
+  A Cheer command driving a Mix task via `use Cheer.MixTask`, which generates the
+  Mix `run/1` entry point (dispatch through the command, `mix greet` program
+  name, and the `exit({:shutdown, 2})` idiom on a usage failure).
 
   ## Examples
 
@@ -15,8 +14,7 @@ defmodule Mix.Tasks.Greet do
       mix greet --help
   """
 
-  use Mix.Task
-  use Cheer.Command
+  use Cheer.MixTask
 
   command "greet" do
     about "Greet someone with style"
@@ -33,25 +31,13 @@ defmodule Mix.Tasks.Greet do
       help: "Repeat the greeting"
   end
 
-  # Mix entry point. Delegate to Cheer and translate a usage failure into the
-  # Mix exit idiom. Do not use Cheer.main/3 here: it calls System.halt, which
-  # hard-kills the VM and skips Mix cleanup.
-  @impl Mix.Task
-  def run(argv) do
-    case Cheer.run(__MODULE__, argv, prog: "mix greet") do
-      {:error, :usage} -> exit({:shutdown, 2})
-      other -> other
-    end
-  end
-
-  # Cheer leaf handler. Runs once argv has parsed and validated cleanly.
   @impl Cheer.Command
   def run(%{name: name} = args, _raw) do
     greeting = "#{args[:greeting]}, #{name}!"
     greeting = if args[:loud], do: String.upcase(greeting), else: greeting
 
     for _ <- 1..args[:times] do
-      IO.puts(greeting)
+      Mix.shell().info(greeting)
     end
 
     :ok

--- a/lib/cheer/mix_task.ex
+++ b/lib/cheer/mix_task.ex
@@ -1,0 +1,86 @@
+defmodule Cheer.MixTask do
+  @moduledoc """
+  Build a Mix task from a Cheer command.
+
+  `use Cheer.MixTask` combines `use Mix.Task` and `use Cheer.Command` and
+  generates the Mix `run/1` entry point. That entry point dispatches argv through
+  the command with `Cheer.run/3`, using `mix <task>` as the program name in help
+  and usage output, and translates a usage failure into `exit({:shutdown, 2})`,
+  the Mix idiom for a nonzero exit.
+
+  Declare the command with the usual DSL and implement the leaf `run/2`:
+
+      defmodule Mix.Tasks.Greet do
+        use Cheer.MixTask
+
+        command "greet" do
+          about "Greet someone"
+          argument :name, type: :string, required: true
+          option :loud, type: :boolean, short: :l
+        end
+
+        @impl Cheer.Command
+        def run(%{name: name} = args, _raw) do
+          greeting = "Hello, \#{name}!"
+          greeting = if args[:loud], do: String.upcase(greeting), else: greeting
+          Mix.shell().info(greeting)
+        end
+      end
+
+  Then `mix greet world --loud` parses, validates, and renders help exactly like
+  a standalone CLI.
+
+  `@shortdoc` defaults to the command's `about` text when it is not set
+  explicitly, so the task lists itself in `mix help`. Override `run/1` if the
+  task needs to do its own setup (such as `Mix.Task.run("app.start")`) before
+  dispatching.
+
+  Do not use `Cheer.main/3` in a Mix task: it calls `System.halt`, which
+  hard-kills the VM and skips Mix's cleanup. This helper uses `Cheer.run/3` and
+  the `exit` idiom instead.
+  """
+
+  defmacro __using__(_opts) do
+    quote do
+      use Mix.Task
+      use Cheer.Command
+
+      @before_compile Cheer.MixTask
+
+      @impl Mix.Task
+      def run(argv) do
+        prog = "mix " <> Cheer.MixTask.__task_name__(__MODULE__)
+
+        case Cheer.run(__MODULE__, argv, prog: prog) do
+          {:error, :usage} -> exit({:shutdown, 2})
+          other -> other
+        end
+      end
+
+      defoverridable run: 1
+    end
+  end
+
+  @doc false
+  defmacro __before_compile__(env) do
+    about = Module.get_attribute(env.module, :cheer_about)
+    shortdoc = Module.get_attribute(env.module, :shortdoc)
+
+    # Surface the command's `about` as the Mix @shortdoc (used by `mix help`)
+    # unless the task set one explicitly.
+    if is_nil(shortdoc) and is_binary(about) and about != "" do
+      Module.put_attribute(env.module, :shortdoc, about)
+    end
+
+    :ok
+  end
+
+  @doc false
+  # Derive the `mix` task name from the module: Mix.Tasks.Db.Migrate -> "db.migrate".
+  def __task_name__(module) do
+    case Module.split(module) do
+      ["Mix", "Tasks" | rest] -> Enum.map_join(rest, ".", &Macro.underscore/1)
+      parts -> Enum.map_join(parts, ".", &Macro.underscore/1)
+    end
+  end
+end

--- a/test/mix_task_test.exs
+++ b/test/mix_task_test.exs
@@ -20,28 +20,32 @@ defmodule Cheer.MixTaskTest do
 
   import ExUnit.CaptureIO
 
+  alias Mix.Tasks.CheerHelperTest
+
   test "run/1 dispatches to the command and returns its value" do
-    assert Mix.Tasks.CheerHelperTest.run(["world"]) == "Hello, world!"
-    assert Mix.Tasks.CheerHelperTest.run(["world", "--loud"]) == "HELLO, WORLD!"
+    assert CheerHelperTest.run(["world"]) == "Hello, world!"
+    assert CheerHelperTest.run(["world", "--loud"]) == "HELLO, WORLD!"
   end
 
   test "run/1 exits with {:shutdown, 2} on a usage failure" do
     capture_io(fn ->
-      assert catch_exit(Mix.Tasks.CheerHelperTest.run([])) == {:shutdown, 2}
+      assert catch_exit(CheerHelperTest.run([])) == {:shutdown, 2}
     end)
   end
 
   test "run/1 renders help with a `mix <task>` program name" do
-    output = capture_io(fn -> Mix.Tasks.CheerHelperTest.run(["--help"]) end)
+    output = capture_io(fn -> CheerHelperTest.run(["--help"]) end)
     assert output =~ "mix cheer_helper_test"
   end
 
   test "@shortdoc defaults to the command about text" do
-    assert Mix.Task.shortdoc(Mix.Tasks.CheerHelperTest) == "Greet from a mix task"
+    assert Mix.Task.shortdoc(CheerHelperTest) == "Greet from a mix task"
   end
 
   test "derives the mix task name from the module" do
-    assert Cheer.MixTask.__task_name__(Mix.Tasks.Db.Migrate) == "db.migrate"
-    assert Cheer.MixTask.__task_name__(Mix.Tasks.Greet) == "greet"
+    assert Cheer.MixTask.__task_name__(CheerHelperTest) == "cheer_helper_test"
+
+    assert Cheer.MixTask.__task_name__(Module.concat(["Mix", "Tasks", "Db", "Migrate"])) ==
+             "db.migrate"
   end
 end

--- a/test/mix_task_test.exs
+++ b/test/mix_task_test.exs
@@ -1,0 +1,47 @@
+defmodule Mix.Tasks.CheerHelperTest do
+  use Cheer.MixTask
+
+  command "cheer_helper_test" do
+    about("Greet from a mix task")
+
+    argument(:name, type: :string, required: true, help: "Who to greet")
+    option(:loud, type: :boolean, short: :l, help: "SHOUT")
+  end
+
+  @impl Cheer.Command
+  def run(%{name: name} = args, _raw) do
+    greeting = "Hello, #{name}!"
+    if args[:loud], do: String.upcase(greeting), else: greeting
+  end
+end
+
+defmodule Cheer.MixTaskTest do
+  use ExUnit.Case, async: true
+
+  import ExUnit.CaptureIO
+
+  test "run/1 dispatches to the command and returns its value" do
+    assert Mix.Tasks.CheerHelperTest.run(["world"]) == "Hello, world!"
+    assert Mix.Tasks.CheerHelperTest.run(["world", "--loud"]) == "HELLO, WORLD!"
+  end
+
+  test "run/1 exits with {:shutdown, 2} on a usage failure" do
+    capture_io(fn ->
+      assert catch_exit(Mix.Tasks.CheerHelperTest.run([])) == {:shutdown, 2}
+    end)
+  end
+
+  test "run/1 renders help with a `mix <task>` program name" do
+    output = capture_io(fn -> Mix.Tasks.CheerHelperTest.run(["--help"]) end)
+    assert output =~ "mix cheer_helper_test"
+  end
+
+  test "@shortdoc defaults to the command about text" do
+    assert Mix.Task.shortdoc(Mix.Tasks.CheerHelperTest) == "Greet from a mix task"
+  end
+
+  test "derives the mix task name from the module" do
+    assert Cheer.MixTask.__task_name__(Mix.Tasks.Db.Migrate) == "db.migrate"
+    assert Cheer.MixTask.__task_name__(Mix.Tasks.Greet) == "greet"
+  end
+end


### PR DESCRIPTION
Closes #55.

`use Cheer.MixTask` makes a Cheer command a Mix task in one line:

```elixir
defmodule Mix.Tasks.Greet do
  use Cheer.MixTask

  command "greet" do
    about "Greet someone"
    argument :name, type: :string, required: true
  end

  @impl Cheer.Command
  def run(%{name: name}, _raw), do: Mix.shell().info("Hello, #{name}!")
end
```

## What it generates

- a `run/1` Mix entry point dispatching argv through the command with `Cheer.run/3`, using `mix <task>` (derived from the module name) as the program name in help/usage;
- a `{:error, :usage}` -> `exit({:shutdown, 2})` translation (the Mix idiom; deliberately not `Cheer.main/3`, which would `System.halt` and skip Mix cleanup);
- `@shortdoc` defaulted to the command's `about`, so the task lists in `mix help`.

`run/1` is `defoverridable` for tasks that need setup (e.g. `Mix.Task.run("app.start")`) before dispatch.

## Verification

Dedicated `test/mix_task_test.exs` (a real `Mix.Tasks.*` using the helper): run/1 delegation and return value, `catch_exit` of the `{:shutdown, 2}` usage path, `mix <task>` program name in help, `@shortdoc` derivation, and task-name derivation. The `examples/mix_task/` project and the cookbook now lead with the helper (manual delegation kept as the under-the-hood equivalent). 298 tests green.