### PR TITLE
fix: no spurious n-in-[] warning for single-sided validate/parse commands

### DIFF
--- a/lib/cheer/command/compiler.ex
+++ b/lib/cheer/command/compiler.ex
@@ -114,25 +114,39 @@ defmodule Cheer.Command.Compiler do
   end
 
   # Reattach generated :validate / :parse accessor fns to the {name, opts} list.
+  # Each reattach branch is only emitted when its list is non-empty; an empty
+  # list would expand to `if n in []`, which the compiler flags as an always-false
+  # conditional in the user's generated __cheer_meta__/0.
   defp merge_accessors(params, has_validate, has_parse) do
     if has_validate == [] and has_parse == [] do
       Macro.escape(params)
     else
       quote do
         Enum.map(unquote(Macro.escape(params)), fn {n, o} ->
-          o =
-            if n in unquote(has_validate),
-              do: Keyword.put(o, :validate, &apply(__MODULE__, :"__cheer_validate_#{n}__", [&1])),
-              else: o
-
-          o =
-            if n in unquote(has_parse),
-              do: Keyword.put(o, :parse, &apply(__MODULE__, :"__cheer_parse_#{n}__", [&1])),
-              else: o
-
+          o = unquote(reattach_step(:validate, has_validate))
+          o = unquote(reattach_step(:parse, has_parse))
           {n, o}
         end)
       end
+    end
+  end
+
+  # An empty list means no such accessor: leave `o` untouched (no `if n in []`).
+  defp reattach_step(_kind, []), do: quote(do: o)
+
+  defp reattach_step(:validate, names) do
+    quote do
+      if n in unquote(names),
+        do: Keyword.put(o, :validate, &apply(__MODULE__, :"__cheer_validate_#{n}__", [&1])),
+        else: o
+    end
+  end
+
+  defp reattach_step(:parse, names) do
+    quote do
+      if n in unquote(names),
+        do: Keyword.put(o, :parse, &apply(__MODULE__, :"__cheer_parse_#{n}__", [&1])),
+        else: o
     end
   end
 

--- a/test/cheer_test.exs
+++ b/test/cheer_test.exs
@@ -3128,4 +3128,38 @@ defmodule CheerTest do
       assert {:ok, %{name: :foo}} = Cheer.run(TestParse, ["foo"])
     end
   end
+
+  # -- Compiler: no n-in-[] warning for single-sided validate/parse (#108) -----
+
+  describe "single-sided validate/parse compilation (#108)" do
+    test "a validate-only command compiles without an always-false conditional warning" do
+      src = """
+      defmodule WarnOnlyValidate do
+        use Cheer.Command
+        command "wov" do
+          option :x, type: :integer, validate: fn n -> if n > 0, do: :ok, else: {:error, "no"} end
+        end
+        def run(a, _r), do: a
+      end
+      """
+
+      warnings = capture_io(:stderr, fn -> Code.compile_string(src) end)
+      refute warnings =~ "always evaluate to false"
+    end
+
+    test "a parse-only command compiles without an always-false conditional warning" do
+      src = """
+      defmodule WarnOnlyParse do
+        use Cheer.Command
+        command "wop" do
+          option :y, type: :string, parse: fn s -> {:ok, String.upcase(s)} end
+        end
+        def run(a, _r), do: a
+      end
+      """
+
+      warnings = capture_io(:stderr, fn -> Code.compile_string(src) end)
+      refute warnings =~ "always evaluate to false"
+    end
+  end
 end


### PR DESCRIPTION
Closes #108.

Regression from the `:parse` refactor (#98). `merge_accessors/3` emitted both `if n in has_validate` and `if n in has_parse` whenever either was non-empty, so a command using only `:validate` (or only `:parse`) generated `if n in []` in its `__cheer_meta__/0` — which Elixir 1.18+ flags as an always-false conditional pointing at the user's own code. Single-sided use is the common case, so nearly every user with a plain `validate:` command hit it.

Fix: emit each reattach branch only when its list is non-empty (empty yields a no-op `o`). Added compile-warning-capturing tests for validate-only and parse-only commands; the warning no longer appears anywhere in the suite. 295 tests green.