### PR TITLE
docs: refresh README features and document typo suggestions, :parse, num_args-on-external

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,19 @@ Cheer.run(MyApp.CLI.Greet, ["world", "--loud"], prog: "greet")
 
 - Declarative macro DSL for commands, options, arguments, and subcommands
 - Typed options and arguments with automatic coercion
-- Repeated (`:multi`) and multi-value (`:num_args`) options
+- Repeated (`:multi`), multi-value (`:num_args`), delimited (`:value_delimiter`),
+  and hyphen-leading (`:allow_hyphen_values`) option values
+- Custom value parsers (`:parse`) that transform input into domain types
 - Per-param and cross-param validation, choices, conditional-required
 - Per-option relations (`:conflicts_with`, `:requires`) and param groups
 - Env var fallback, defaults, boolean negation (`--no-*`)
-- Auto-generated help with headings, display order, before/after text
-- Subcommand prefix inference and `"Did you mean?"` suggestions
+- Auto-generated help with headings, display order, before/after text, and
+  hidden options, arguments, and subcommands (`hide`)
+- Prefix inference and `"Did you mean?"` suggestions for mistyped commands and
+  flags
 - Optional subcommands (`:args_conflicts_with_subcommands`) and external
   subcommands for git-style plugin dispatchers
+- Escript and Mix task entry points (`Cheer.MixTask`)
 - Shell completion for bash, zsh, fish, and PowerShell
 - REPL mode driven by the same command tree
 - In-process test runner with output capture

--- a/docs/guides/help_and_output.md
+++ b/docs/guides/help_and_output.md
@@ -99,6 +99,23 @@ Hidden items are still accepted by the parser and a hidden subcommand is still
 dispatchable; they are only omitted from help output, shell completion, and the
 "Available commands" list shown on an unknown-command error.
 
+## Did you mean?
+
+On an unknown command or an unknown flag, Cheer suggests the closest declared
+name (by Jaro distance) if one is near enough:
+
+```
+$ myapp --colr red
+error: unknown option(s): --colr
+
+  Did you mean '--color'?
+```
+
+Flag suggestions match against declared option names and their aliases. A known
+option given a bad value is not treated as a typo, so it never suggests the flag
+you already typed. Subcommand suggestions work the same way on an unknown
+command.
+
 ## Flag naming
 
 Cheer converts atom option names to kebab-case in both the parser and help

--- a/docs/guides/options.md
+++ b/docs/guides/options.md
@@ -108,6 +108,20 @@ Each element is coerced to the option's `:type` and validated against
 `:multi` (each occurrence is split and the results flattened). This differs
 from `:num_args`, which reads several separate tokens after one flag.
 
+## Custom value parsers (`:parse`)
+
+`:parse` transforms a value into a domain type (an atom, a `Date`, a struct)
+after `:type` coercion. See [Validation](validation.md) for the full contract:
+
+```elixir
+option :mode, type: :string, parse: fn
+  "r" -> {:ok, :read}
+  "w" -> {:ok, :write}
+  _ -> {:error, "must be r or w"}
+end
+# --mode r  ->  args[:mode] == :read
+```
+
 ## Aliases (long-form)
 
 ```elixir

--- a/docs/guides/subcommands.md
+++ b/docs/guides/subcommands.md
@@ -122,6 +122,9 @@ Behavior:
   flags the parent does not know about.
 - `args[:external_subcommand]` is `nil` when no external sub was invoked,
   `{name, rest}` when one was. Pattern matches are total.
+- The parent's own options parse before the external subcommand name, including
+  `:num_args` options: `my-tool --point 1 2 status` gives the parent
+  `point: [1, 2]` and the external sub `{"status", []}`.
 
 ## Optional subcommand (run the parent on an unknown token)
 


### PR DESCRIPTION
Closes #112.

Documentation-only refresh for shipped features flagged in the release audit.

- **README Features**: adds `value_delimiter`, `allow_hyphen_values`, `:parse`, command-level `hide`, unknown-flag suggestions, and `Cheer.MixTask`.
- **help_and_output.md**: documents the unknown-flag "Did you mean?" suggestion (including that a bad-value case does not self-suggest).
- **options.md**: surfaces `:parse` alongside the sibling value-transform options.
- **subcommands.md**: notes `num_args` options parse before the external subcommand name.

`mix docs` builds clean.