### PR TITLE
fix(router): external-subcommand parity, positional error labels, user-fn exceptions

### DIFF
--- a/lib/cheer/router.ex
+++ b/lib/cheer/router.ex
@@ -308,13 +308,15 @@ defmodule Cheer.Router do
           :handled
 
         true ->
-          with {:ok, args} <- apply_parsers(args, all_options ++ meta.arguments),
+          arg_names = MapSet.new(meta.arguments, fn {n, _} -> n end)
+
+          with {:ok, args} <- apply_parsers(args, all_options ++ meta.arguments, arg_names),
                :ok <- validate_num_args(num_args_values, all_options),
                :ok <- validate_conditional_required(args, all_options, provided),
                :ok <- validate_constraints(all_options, provided),
                :ok <- validate_groups(provided, Map.get(meta, :groups, %{})),
                # Include arguments so argument-level :validate and :choices run.
-               :ok <- validate_params(args, all_options ++ meta.arguments),
+               :ok <- validate_params(args, all_options ++ meta.arguments, arg_names),
                :ok <- run_validators(args, Map.get(meta, :validators, [])) do
             {:ok, args}
           else
@@ -340,12 +342,16 @@ defmodule Cheer.Router do
 
     all_options = meta.options ++ inherited_globals
 
-    # Pull num_args flags out first (head mode: stop at the external subcommand),
-    # then parse the remainder. OptionParser cannot express multi-value flags.
+    # Pull num_args and hyphen-value flags out first (head mode: stop at the
+    # external subcommand), then parse the remainder. OptionParser cannot express
+    # multi-value flags or `-`-leading values.
     {num_args_values, argv} = extract_num_args(argv, all_options, true)
+    {hyphen_values, argv} = extract_hyphen_values(argv, all_options, true)
 
     parser_options =
-      Enum.reject(all_options, fn {_name, o} -> Keyword.has_key?(o, :num_args) end)
+      Enum.reject(all_options, fn {_name, o} = opt ->
+        Keyword.has_key?(o, :num_args) or single_value_hyphen_opt?(opt)
+      end)
 
     {option_parser_opts, option_aliases} = build_option_parser_spec(parser_options)
 
@@ -361,6 +367,8 @@ defmodule Cheer.Router do
       args = apply_env_vars(args, all_options)
       args = Map.merge(args, parsed_map)
       args = Map.merge(args, num_args_values)
+      args = Map.merge(args, hyphen_values)
+      args = apply_value_delimiters(args, all_options)
 
       args =
         case positional do
@@ -368,7 +376,8 @@ defmodule Cheer.Router do
           [name | rest] -> Map.put(args, :external_subcommand, {name, rest})
         end
 
-      provided = MapSet.new(Map.keys(parsed_map) ++ Map.keys(num_args_values))
+      provided =
+        MapSet.new(Map.keys(parsed_map) ++ Map.keys(num_args_values) ++ Map.keys(hyphen_values))
 
       missing = missing_required_options(all_options, args)
 
@@ -378,13 +387,15 @@ defmodule Cheer.Router do
           :handled
 
         true ->
-          with {:ok, args} <- apply_parsers(args, all_options ++ meta.arguments),
+          arg_names = MapSet.new(meta.arguments, fn {n, _} -> n end)
+
+          with {:ok, args} <- apply_parsers(args, all_options ++ meta.arguments, arg_names),
                :ok <- validate_num_args(num_args_values, all_options),
                :ok <- validate_conditional_required(args, all_options, provided),
                :ok <- validate_constraints(all_options, provided),
                :ok <- validate_groups(provided, Map.get(meta, :groups, %{})),
                # Include arguments so argument-level :validate and :choices run.
-               :ok <- validate_params(args, all_options ++ meta.arguments),
+               :ok <- validate_params(args, all_options ++ meta.arguments, arg_names),
                :ok <- run_validators(args, Map.get(meta, :validators, [])) do
             {:ok, args}
           else
@@ -656,13 +667,13 @@ defmodule Cheer.Router do
   # Apply each param's :parse fn to its value, transforming it into a domain
   # value. Runs before validation so :choices/:validate see the parsed value. A
   # list value (multi, num_args, value_delimiter) is parsed element-wise.
-  defp apply_parsers(args, params) do
+  defp apply_parsers(args, params, arg_names) do
     Enum.reduce_while(params, {:ok, args}, fn {name, opts}, {:ok, acc} ->
       with fun when is_function(fun, 1) <- Keyword.get(opts, :parse),
            {:ok, value} <- Map.fetch(acc, name) do
         case apply_parse_value(fun, value) do
           {:ok, parsed} -> {:cont, {:ok, Map.put(acc, name, parsed)}}
-          {:error, msg} -> {:halt, {:error, "--#{flag_string(name)}: #{msg}"}}
+          {:error, msg} -> {:halt, {:error, "#{param_label(name, arg_names)}: #{msg}"}}
         end
       else
         _ -> {:cont, {:ok, acc}}
@@ -672,7 +683,7 @@ defmodule Cheer.Router do
 
   defp apply_parse_value(fun, values) when is_list(values) do
     Enum.reduce_while(values, {:ok, []}, fn v, {:ok, acc} ->
-      case fun.(v) do
+      case call_user_fun(fun, v) do
         {:ok, parsed} -> {:cont, {:ok, [parsed | acc]}}
         {:error, _} = err -> {:halt, err}
       end
@@ -683,13 +694,22 @@ defmodule Cheer.Router do
     end
   end
 
-  defp apply_parse_value(fun, value), do: fun.(value)
+  defp apply_parse_value(fun, value), do: call_user_fun(fun, value)
 
-  defp validate_params(args, options) do
+  # Run a user-supplied :parse / :validate function, turning a raised exception
+  # into a clean {:error, msg} so a buggy function cannot crash the whole program
+  # (and defeat Cheer.main/3's exit-code handling).
+  defp call_user_fun(fun, value) do
+    fun.(value)
+  rescue
+    e -> {:error, Exception.message(e)}
+  end
+
+  defp validate_params(args, options, arg_names) do
     Enum.reduce_while(options, :ok, fn {name, opts}, _acc ->
       case Map.fetch(args, name) do
         {:ok, value} ->
-          with :ok <- validate_choices(name, value, opts),
+          with :ok <- validate_choices(name, value, opts, arg_names),
                :ok <- validate_custom(name, value, opts) do
             {:cont, :ok}
           else
@@ -702,7 +722,7 @@ defmodule Cheer.Router do
     end)
   end
 
-  defp validate_choices(name, value, opts) do
+  defp validate_choices(name, value, opts, arg_names) do
     case Keyword.get(opts, :choices) do
       nil ->
         :ok
@@ -714,7 +734,7 @@ defmodule Cheer.Router do
         if Enum.all?(values, &(to_string(&1) in allowed)) do
           :ok
         else
-          {:error, "--#{name} must be one of: #{Enum.join(choices, ", ")}"}
+          {:error, "#{param_label(name, arg_names)} must be one of: #{Enum.join(choices, ", ")}"}
         end
     end
   end
@@ -722,8 +742,13 @@ defmodule Cheer.Router do
   defp validate_custom(_name, value, opts) do
     case Keyword.get(opts, :validate) do
       nil -> :ok
-      fun when is_function(fun, 1) -> fun.(value)
+      fun when is_function(fun, 1) -> call_user_fun(fun, value)
     end
+  end
+
+  # A positional argument renders as <name>; an option as its kebab-cased flag.
+  defp param_label(name, arg_names) do
+    if MapSet.member?(arg_names, name), do: "<#{name}>", else: "--#{flag_string(name)}"
   end
 
   # -- Cross-param validators --
@@ -841,13 +866,16 @@ defmodule Cheer.Router do
   # Options with `allow_hyphen_values: true` that take a single value (not
   # num_args, boolean, or count) must have their value pulled out before
   # OptionParser, which would otherwise treat a `-`-prefixed value as a flag.
-  defp extract_hyphen_values(argv, options) do
+  #
+  # `head?` (external_subcommands) stops extraction at the first positional so
+  # the external subcommand name and its args are left for parse_head.
+  defp extract_hyphen_values(argv, options, head? \\ false) do
     hyphen_opts = Enum.filter(options, &single_value_hyphen_opt?/1)
 
     if hyphen_opts == [] do
       {%{}, argv}
     else
-      do_extract_hyphen_values(argv, num_args_lookup(hyphen_opts), %{}, [])
+      do_extract_hyphen_values(argv, num_args_lookup(hyphen_opts), %{}, [], head?)
     end
   end
 
@@ -857,31 +885,36 @@ defmodule Cheer.Router do
       Keyword.get(o, :type, :string) not in [:boolean, :count]
   end
 
-  defp do_extract_hyphen_values([], _lookup, collected, residual),
+  defp do_extract_hyphen_values([], _lookup, collected, residual, _head?),
     do: {collected, Enum.reverse(residual)}
 
-  defp do_extract_hyphen_values(["--" | rest], _lookup, collected, residual),
+  defp do_extract_hyphen_values(["--" | rest], _lookup, collected, residual, _head?),
     do: {collected, Enum.reverse(residual) ++ ["--" | rest]}
 
-  defp do_extract_hyphen_values([token | rest], lookup, collected, residual) do
+  defp do_extract_hyphen_values([token | rest] = all, lookup, collected, residual, head?) do
     case num_args_flag(token, lookup) do
       {{name, opts}, nil} ->
         case rest do
           [value | rest2] ->
             collected = Map.put(collected, name, coerce_arg(value, opts))
-            do_extract_hyphen_values(rest2, lookup, collected, residual)
+            do_extract_hyphen_values(rest2, lookup, collected, residual, head?)
 
           [] ->
             # Flag with no following value: leave it for the normal parse path.
-            do_extract_hyphen_values([], lookup, collected, [token | residual])
+            do_extract_hyphen_values([], lookup, collected, [token | residual], head?)
         end
 
       {{name, opts}, inline} ->
         collected = Map.put(collected, name, coerce_arg(inline, opts))
-        do_extract_hyphen_values(rest, lookup, collected, residual)
+        do_extract_hyphen_values(rest, lookup, collected, residual, head?)
 
       :nomatch ->
-        do_extract_hyphen_values(rest, lookup, collected, [token | residual])
+        # In head mode the first positional is the external subcommand: stop.
+        if head? and not String.starts_with?(token, "-") do
+          {collected, Enum.reverse(residual) ++ all}
+        else
+          do_extract_hyphen_values(rest, lookup, collected, [token | residual], head?)
+        end
     end
   end
 

--- a/test/cheer_test.exs
+++ b/test/cheer_test.exs
@@ -3162,4 +3162,87 @@ defmodule CheerTest do
       refute warnings =~ "always evaluate to false"
     end
   end
+
+  # -- Router robustness (#109 #110 #111) --------------------------------------
+
+  defmodule TestExtValueXform do
+    use Cheer.Command
+
+    command "extx" do
+      external_subcommands(true)
+      option(:tags, type: :string, value_delimiter: ",")
+      option(:pattern, type: :string, allow_hyphen_values: true)
+    end
+
+    @impl Cheer.Command
+    def run(args, _raw), do: {:ok, args}
+  end
+
+  defmodule TestMsgStyle do
+    use Cheer.Command
+
+    command "msg" do
+      argument(:color, type: :string, required: true, choices: ["red", "green"])
+      option(:log_level, type: :string, choices: ["info", "warn"])
+    end
+
+    @impl Cheer.Command
+    def run(args, _raw), do: {:ok, args}
+  end
+
+  defmodule TestRaising do
+    use Cheer.Command
+
+    command "rz" do
+      option(:p, type: :string, parse: fn _ -> raise "boom" end)
+      option(:v, type: :string, validate: fn _ -> raise "argh" end)
+    end
+
+    @impl Cheer.Command
+    def run(args, _raw), do: {:ok, args}
+  end
+
+  describe "value_delimiter and allow_hyphen_values under external_subcommands (#109)" do
+    test "value_delimiter is split on an external-subcommand command" do
+      assert {:ok, args} = Cheer.run(TestExtValueXform, ["--tags", "a,b,c", "deploy"])
+      assert args[:tags] == ["a", "b", "c"]
+      assert args[:external_subcommand] == {"deploy", []}
+    end
+
+    test "single-value allow_hyphen_values works on an external-subcommand command" do
+      assert {:ok, args} = Cheer.run(TestExtValueXform, ["--pattern", "-foo", "deploy"])
+      assert args[:pattern] == "-foo"
+      assert args[:external_subcommand] == {"deploy", []}
+    end
+  end
+
+  describe "choices error message styling (#110)" do
+    test "a positional argument renders as <name>, not a flag" do
+      output = capture_io(fn -> Cheer.run(TestMsgStyle, ["blue"]) end)
+      assert output =~ "<color> must be one of"
+      refute output =~ "--color"
+    end
+
+    test "an option name is kebab-cased in the error" do
+      output = capture_io(fn -> Cheer.run(TestMsgStyle, ["red", "--log-level", "bad"]) end)
+      assert output =~ "--log-level must be one of"
+      refute output =~ "--log_level"
+    end
+  end
+
+  describe "raising :parse / :validate functions (#111)" do
+    test "a raising :parse yields a clean usage error, not a crash" do
+      output =
+        capture_io(fn -> assert Cheer.run(TestRaising, ["--p", "x"]) == {:error, :usage} end)
+
+      assert output =~ "--p: boom"
+    end
+
+    test "a raising :validate yields a clean usage error, not a crash" do
+      output =
+        capture_io(fn -> assert Cheer.run(TestRaising, ["--v", "x"]) == {:error, :usage} end)
+
+      assert output =~ "argh"
+    end
+  end
 end


### PR DESCRIPTION
Closes #109. Closes #110. Closes #111.

Three related router robustness fixes from the release audit.

## #109 external_subcommands feature parity

`parse_with_external_subcommand` ran `extract_num_args` and `apply_parsers` but not `extract_hyphen_values` or `apply_value_delimiters`, so `:value_delimiter` and single-value `:allow_hyphen_values` were silently dropped on external-subcommand commands. Added a `head?` flag to `extract_hyphen_values` (mirroring `extract_num_args`) and wired both passes into the external path. `--tags a,b,c deploy` now splits; `--pattern -foo deploy` now works.

## #110 error-message styling

`:choices` and `:parse` errors rendered a positional argument as `--name` (flag style, raw atom). Now they render `<color>` for a positional and the kebab-cased `--log-level` for an option, via a shared `param_label/2`. (Exposed by #91, which routed arguments through `validate_choices`.)

## #111 user-function exceptions

A `:parse` or `:validate` function that raises now yields a clean usage error instead of a stacktrace that would take down the whole program (and defeat `Cheer.main/3`), via `call_user_fun/2`.

Verified matrix in tests. 306 tests green.