### PR TITLE
test: cover main exit codes, env :count edges, and :parse interactions

### DIFF
--- a/lib/cheer.ex
+++ b/lib/cheer.ex
@@ -76,11 +76,18 @@ defmodule Cheer do
   @dialyzer {:nowarn_function, [main: 2, main: 3]}
   @spec main(module(), [String.t()], keyword()) :: no_return()
   def main(root_command, argv, opts \\ []) do
-    case run(root_command, argv, opts) do
-      {:error, :usage} -> System.halt(2)
-      _ -> System.halt(0)
-    end
+    root_command
+    |> run(argv, opts)
+    |> exit_code()
+    |> System.halt()
   end
+
+  @doc false
+  # Maps a `run/3` result to a conventional process exit code: 2 on a usage
+  # failure, 0 otherwise. Pure and testable, unlike `main/3` which halts.
+  @spec exit_code(term()) :: 0 | 2
+  def exit_code({:error, :usage}), do: 2
+  def exit_code(_), do: 0
 
   @doc """
   Returns the command tree as a nested data structure.

--- a/test/cheer_test.exs
+++ b/test/cheer_test.exs
@@ -3245,4 +3245,72 @@ defmodule CheerTest do
       assert output =~ "argh"
     end
   end
+
+  # -- Release-audit coverage gaps (#113) --------------------------------------
+
+  describe "Cheer.exit_code/1 (main exit-code mapping)" do
+    test "maps a usage failure to 2 and anything else to 0" do
+      assert Cheer.exit_code({:error, :usage}) == 2
+      assert Cheer.exit_code(:ok) == 0
+      assert Cheer.exit_code({:ok, %{}}) == 0
+      assert Cheer.exit_code("some run/2 result") == 0
+    end
+  end
+
+  describe "env :count coercion edge cases (#113)" do
+    test "a non-numeric env value floors to 0" do
+      System.put_env("TEST_CHEER_LEVEL", "notanint")
+      assert {:ok, %{level: 0}} = Cheer.run(TestCountEnv, [])
+    after
+      System.delete_env("TEST_CHEER_LEVEL")
+    end
+
+    test "a float-string env value floors to 0 (no partial parse)" do
+      System.put_env("TEST_CHEER_LEVEL", "3.9")
+      assert {:ok, %{level: 0}} = Cheer.run(TestCountEnv, [])
+    after
+      System.delete_env("TEST_CHEER_LEVEL")
+    end
+  end
+
+  defmodule TestParseInteractions do
+    use Cheer.Command
+
+    command "pi" do
+      option(:m,
+        type: :string,
+        parse: fn s -> {:ok, String.upcase(s)} end,
+        choices: ["READ", "WRITE"]
+      )
+
+      option(:n, type: :integer, multi: true, parse: fn i -> {:ok, i * 10} end)
+
+      option(:ids,
+        type: :string,
+        value_delimiter: ",",
+        parse: fn s -> if s == "bad", do: {:error, "no bad"}, else: {:ok, s} end
+      )
+    end
+
+    @impl Cheer.Command
+    def run(args, _raw), do: {:ok, args}
+  end
+
+  describe ":parse interactions (#113)" do
+    test ":choices validates the post-parse value" do
+      assert {:ok, %{m: "READ"}} = Cheer.run(TestParseInteractions, ["--m", "read"])
+
+      output = capture_io(fn -> Cheer.run(TestParseInteractions, ["--m", "nope"]) end)
+      assert output =~ "must be one of"
+    end
+
+    test ":parse applies element-wise to a :multi value" do
+      assert {:ok, %{n: [10, 20]}} = Cheer.run(TestParseInteractions, ["--n", "1", "--n", "2"])
+    end
+
+    test ":parse halts on the first failing element of a list" do
+      output = capture_io(fn -> Cheer.run(TestParseInteractions, ["--ids", "ok,bad,also"]) end)
+      assert output =~ "--ids: no bad"
+    end
+  end
 end


### PR DESCRIPTION
Closes #113.

Fills the release-audit test gaps.

- **`Cheer.main` exit codes**: extracted the result-to-exit-code mapping into a pure `Cheer.exit_code/1` (`main/3` now pipes through it), so the `2`-on-usage / `0`-otherwise mapping is testable without halting the VM.
- **env `:count` edges**: non-numeric and float-string values both floor to `0` (no partial parse).
- **`:parse` interaction locks** (previously working but untested): `:choices` validates the post-parse value, `:parse` applies element-wise to `:multi`, and it halts on the first failing list element.

Test-only plus the small `exit_code/1` extraction. 312 tests green.