### PR TITLE
feat: required (one-of) param group constraint

### DIFF
--- a/docs/guides/constraints.md
+++ b/docs/guides/constraints.md
@@ -101,6 +101,24 @@ end
 error: options --username, --password must be used together (group: auth)
 ```
 
+### Required (one-of)
+
+At least one of the group's options must be set:
+
+```elixir
+group :source, required: true do
+  option :file, type: :string
+  option :stdin, type: :boolean
+end
+```
+
+```
+error: one of --file, --stdin is required (group: source)
+```
+
+Constraints combine: `mutually_exclusive: true, required: true` means exactly one
+member must be set.
+
 ## Picking the right tool
 
 - One option conditionally required based on another's **value**: `:required_if`.

--- a/lib/cheer/command/dsl.ex
+++ b/lib/cheer/command/dsl.ex
@@ -330,6 +330,10 @@ defmodule Cheer.Command.DSL do
   Supports:
     * `mutually_exclusive: true` -- at most one option in the group can be set
     * `co_occurring: true` -- all or none of the options must be set
+    * `required: true` -- at least one option in the group must be set
+
+  Constraints combine: `mutually_exclusive: true, required: true` means exactly
+  one member must be set.
   """
   defmacro group(name, opts, do: block) do
     quote do

--- a/lib/cheer/router.ex
+++ b/lib/cheer/router.ex
@@ -555,6 +555,10 @@ defmodule Cheer.Router do
           flags = Enum.map_join(members, ", ", &"--#{flag_string(&1)}")
           {:halt, {:error, "options #{flags} must be used together (group: #{name})"}}
 
+        Keyword.get(opts, :required, false) and set_members == [] ->
+          flags = Enum.map_join(members, ", ", &"--#{flag_string(&1)}")
+          {:halt, {:error, "one of #{flags} is required (group: #{name})"}}
+
         true ->
           {:cont, :ok}
       end

--- a/test/cheer_test.exs
+++ b/test/cheer_test.exs
@@ -1132,6 +1132,46 @@ defmodule CheerTest do
     end
   end
 
+  defmodule TestRequiredGroup do
+    use Cheer.Command
+
+    command "rg" do
+      group :src, required: true do
+        option(:file, type: :string)
+        option(:stdin, type: :boolean)
+      end
+
+      group :one, required: true, mutually_exclusive: true do
+        option(:a, type: :boolean)
+        option(:b, type: :boolean)
+      end
+    end
+
+    @impl Cheer.Command
+    def run(args, _raw), do: {:ok, args}
+  end
+
+  describe "required group (#100)" do
+    test "errors when no member of a required group is provided" do
+      output = capture_io(fn -> Cheer.run(TestRequiredGroup, ["--a"]) end)
+      assert output =~ "one of --file, --stdin is required (group: src)"
+    end
+
+    test "accepts when at least one member is provided" do
+      assert {:ok, _} = Cheer.run(TestRequiredGroup, ["--file", "x", "--a"])
+    end
+
+    test "required + mutually_exclusive means exactly one" do
+      assert {:ok, _} = Cheer.run(TestRequiredGroup, ["--file", "x", "--a"])
+
+      none = capture_io(fn -> Cheer.run(TestRequiredGroup, ["--file", "x"]) end)
+      assert none =~ "one of --a, --b is required"
+
+      both = capture_io(fn -> Cheer.run(TestRequiredGroup, ["--file", "x", "--a", "--b"]) end)
+      assert both =~ "mutually exclusive"
+    end
+  end
+
   # -- "Did you mean?" suggestions --------------------------------------------
 
   describe "typo suggestions" do


### PR DESCRIPTION
Closes #100.

Adds `required: true` to param groups: at least one member must be set.

```elixir
group :source, required: true do
  option :file, type: :string
  option :stdin, type: :boolean
end
# none provided -> error: one of --file, --stdin is required (group: source)
```

Combines with the existing constraints: `mutually_exclusive: true, required: true` means exactly one member. Keyed off the same user-supplied provenance set as the other group checks, so a defaulted member does not satisfy it. No DSL change (the `group` macro already passes opts through); doc + tests added. 315 tests green.