### PR TITLE
feat: required_if_all and required_unless_all conditional-required variants

### DIFF
--- a/docs/guides/constraints.md
+++ b/docs/guides/constraints.md
@@ -24,6 +24,13 @@ Multiple conditions: any match triggers the requirement.
 option :region, type: :string, required_if: [env: "prod", env: "staging"]
 ```
 
+Use `:required_if_all` when every condition must hold instead of any:
+
+```elixir
+option :confirm, type: :boolean, required_if_all: [env: "prod", force: true]
+# error: --confirm is required when --env is 'prod' and --force is true
+```
+
 ### `:required_unless`
 
 Required unless any of the named options is present. Accepts an atom or a
@@ -36,6 +43,14 @@ option :config, type: :string, required_unless: [:inline, :stdin]
 
 ```
 error: --config is required unless --inline, --stdin is provided
+```
+
+Use `:required_unless_all` to require the option unless *all* of the named
+options are present:
+
+```elixir
+option :out, type: :string, required_unless_all: [:a, :b]
+# error: --out is required unless --a, --b are all provided
 ```
 
 ## Per-option relations

--- a/lib/cheer/command/dsl.ex
+++ b/lib/cheer/command/dsl.ex
@@ -240,8 +240,12 @@ defmodule Cheer.Command.DSL do
     * `:requires` - atom or list of atoms; the named option(s) must also be present
     * `:required_if` - keyword list `[other_opt: value]`; this option is required when
       any pair matches (i.e. `args[other_opt] == value`)
+    * `:required_if_all` - keyword list `[other_opt: value]`; required only when
+      every pair matches
     * `:required_unless` - atom or list of atoms; this option is required unless any
       of the named options are present
+    * `:required_unless_all` - list of atoms; required unless all of the named
+      options are present
     * `:validate` - `fn value -> :ok | {:error, msg} end`
 
   Boolean options automatically support `--no-<name>` negation (e.g. `--no-color`).

--- a/lib/cheer/router.ex
+++ b/lib/cheer/router.ex
@@ -463,9 +463,47 @@ defmodule Cheer.Router do
             "--#{flag_string(name)} is required unless #{format_dep_list(deps)} is provided"}}
         end
 
+      Keyword.has_key?(opts, :required_if_all) ->
+        checks = Keyword.fetch!(opts, :required_if_all)
+
+        if match_required_if_all?(checks, args, provided) do
+          {:halt, {:error, "--#{flag_string(name)} is required when #{format_if_all(checks)}"}}
+        else
+          {:cont, :ok}
+        end
+
+      Keyword.has_key?(opts, :required_unless_all) ->
+        deps = Keyword.fetch!(opts, :required_unless_all)
+
+        if all_present?(deps, provided) do
+          {:cont, :ok}
+        else
+          {:halt,
+           {:error,
+            "--#{flag_string(name)} is required unless #{format_dep_list(deps)} are all provided"}}
+        end
+
       true ->
         {:cont, :ok}
     end
+  end
+
+  # required_if matches when ANY condition holds; required_if_all when they all do.
+  defp match_required_if_all?(checks, args, provided) when is_list(checks) do
+    Enum.all?(checks, fn {dep, expected} ->
+      MapSet.member?(provided, dep) and match?({:ok, ^expected}, Map.fetch(args, dep))
+    end)
+  end
+
+  defp all_present?(name, provided) when is_atom(name), do: MapSet.member?(provided, name)
+
+  defp all_present?(names, provided) when is_list(names),
+    do: Enum.all?(names, &MapSet.member?(provided, &1))
+
+  defp format_if_all(checks) do
+    Enum.map_join(checks, " and ", fn {dep, val} ->
+      "--#{flag_string(dep)} is #{format_required_value(val)}"
+    end)
   end
 
   # Only deps the user actually supplied can trigger a required_if: a dependency

--- a/test/cheer_test.exs
+++ b/test/cheer_test.exs
@@ -2698,14 +2698,23 @@ defmodule CheerTest do
     end
   end
 
-  defmodule TestConditionalAll do
+  defmodule TestRequiredUnlessAll do
     use Cheer.Command
 
-    command "ca" do
+    command "rua" do
       option(:a, type: :boolean)
       option(:b, type: :boolean)
       option(:out, type: :string, required_unless_all: [:a, :b])
+    end
 
+    @impl Cheer.Command
+    def run(args, _raw), do: {:ok, args}
+  end
+
+  defmodule TestRequiredIfAll do
+    use Cheer.Command
+
+    command "ria" do
       option(:env, type: :string)
       option(:force, type: :boolean)
       option(:confirm, type: :boolean, required_if_all: [env: "prod", force: true])
@@ -2717,21 +2726,21 @@ defmodule CheerTest do
 
   describe "required_unless_all and required_if_all (#107)" do
     test "required_unless_all errors unless every dependency is present" do
-      out = capture_io(fn -> Cheer.run(TestConditionalAll, ["--a"]) end)
+      out = capture_io(fn -> Cheer.run(TestRequiredUnlessAll, ["--a"]) end)
       assert out =~ "--out is required unless --a, --b are all provided"
     end
 
     test "required_unless_all is satisfied when all dependencies are present" do
-      assert {:ok, _} = Cheer.run(TestConditionalAll, ["--a", "--b"])
+      assert {:ok, _} = Cheer.run(TestRequiredUnlessAll, ["--a", "--b"])
     end
 
     test "required_if_all fires only when every condition matches" do
-      out = capture_io(fn -> Cheer.run(TestConditionalAll, ["--env", "prod", "--force"]) end)
+      out = capture_io(fn -> Cheer.run(TestRequiredIfAll, ["--env", "prod", "--force"]) end)
       assert out =~ "--confirm is required when --env is 'prod' and --force is true"
     end
 
     test "required_if_all does not fire when only some conditions match" do
-      assert {:ok, _} = Cheer.run(TestConditionalAll, ["--env", "prod"])
+      assert {:ok, _} = Cheer.run(TestRequiredIfAll, ["--env", "prod"])
     end
   end
 

--- a/test/cheer_test.exs
+++ b/test/cheer_test.exs
@@ -2698,6 +2698,43 @@ defmodule CheerTest do
     end
   end
 
+  defmodule TestConditionalAll do
+    use Cheer.Command
+
+    command "ca" do
+      option(:a, type: :boolean)
+      option(:b, type: :boolean)
+      option(:out, type: :string, required_unless_all: [:a, :b])
+
+      option(:env, type: :string)
+      option(:force, type: :boolean)
+      option(:confirm, type: :boolean, required_if_all: [env: "prod", force: true])
+    end
+
+    @impl Cheer.Command
+    def run(args, _raw), do: {:ok, args}
+  end
+
+  describe "required_unless_all and required_if_all (#107)" do
+    test "required_unless_all errors unless every dependency is present" do
+      out = capture_io(fn -> Cheer.run(TestConditionalAll, ["--a"]) end)
+      assert out =~ "--out is required unless --a, --b are all provided"
+    end
+
+    test "required_unless_all is satisfied when all dependencies are present" do
+      assert {:ok, _} = Cheer.run(TestConditionalAll, ["--a", "--b"])
+    end
+
+    test "required_if_all fires only when every condition matches" do
+      out = capture_io(fn -> Cheer.run(TestConditionalAll, ["--env", "prod", "--force"]) end)
+      assert out =~ "--confirm is required when --env is 'prod' and --force is true"
+    end
+
+    test "required_if_all does not fire when only some conditions match" do
+      assert {:ok, _} = Cheer.run(TestConditionalAll, ["--env", "prod"])
+    end
+  end
+
   # -- Constraint provenance: defaults must not read as "provided" (#59) --------
 
   defmodule TestProvenance do


### PR DESCRIPTION
Closes #107.

The existing `:required_if` fires when ANY `[dep: value]` pair matches, and `:required_unless` is satisfied when ANY named option is present. This adds the all-form counterparts:

- **`:required_if_all`** — required only when every `[dep: value]` pair matches (e.g. `required_if_all: [env: "prod", force: true]`).
- **`:required_unless_all`** — required unless all of the named options are present (e.g. `required_unless_all: [:a, :b]`).

Note: the issue mentioned `required_if_any`, but `:required_if` is already the any-match form, so the genuinely-new variant is `:required_if_all`. Both key off the same user-supplied provenance set as the existing checks. Doc + tests added; 319 tests green.