### PR TITLE
feat: deprecation markers for options, arguments, and subcommands

### DIFF
--- a/docs/guides/help_and_output.md
+++ b/docs/guides/help_and_output.md
@@ -116,6 +116,29 @@ option given a bad value is not treated as a typo, so it never suggests the flag
 you already typed. Subcommand suggestions work the same way on an unknown
 command.
 
+## Deprecation
+
+Mark an option, argument, or subcommand deprecated with `:deprecated` (options
+and arguments) or the `deprecated` command setting (subcommands). Pass `true`
+for a bare marker or a string for a reason:
+
+```elixir
+option :old_flag, type: :string, deprecated: "use --new-flag"
+
+command "old-name" do
+  deprecated "use `new-name` instead"
+end
+```
+
+Deprecated items still work. Help shows a `(deprecated)` marker (with the reason,
+if given), and using a deprecated option or subcommand prints a warning to
+stderr:
+
+```
+warning: --old-flag is deprecated: use --new-flag
+warning: command 'old-name' is deprecated: use `new-name` instead
+```
+
 ## Flag naming
 
 Cheer converts atom option names to kebab-case in both the parser and help

--- a/lib/cheer/command.ex
+++ b/lib/cheer/command.ex
@@ -45,6 +45,7 @@ defmodule Cheer.Command do
       Module.register_attribute(__MODULE__, :cheer_aliases, accumulate: false)
       Module.register_attribute(__MODULE__, :cheer_usage, accumulate: false)
       Module.register_attribute(__MODULE__, :cheer_hide, accumulate: false)
+      Module.register_attribute(__MODULE__, :cheer_deprecated, accumulate: false)
       Module.register_attribute(__MODULE__, :cheer_subcommand_required, accumulate: false)
       Module.register_attribute(__MODULE__, :cheer_propagate_version, accumulate: false)
       Module.register_attribute(__MODULE__, :cheer_infer_subcommands, accumulate: false)

--- a/lib/cheer/command/compiler.ex
+++ b/lib/cheer/command/compiler.ex
@@ -14,6 +14,7 @@ defmodule Cheer.Command.Compiler do
     aliases = Module.get_attribute(env.module, :cheer_aliases) || []
     usage = Module.get_attribute(env.module, :cheer_usage)
     hide = Module.get_attribute(env.module, :cheer_hide) || false
+    deprecated = Module.get_attribute(env.module, :cheer_deprecated) || false
     subcommand_required = Module.get_attribute(env.module, :cheer_subcommand_required) || false
     propagate_version = Module.get_attribute(env.module, :cheer_propagate_version) || false
     infer_subcommands = Module.get_attribute(env.module, :cheer_infer_subcommands) || false
@@ -93,6 +94,7 @@ defmodule Cheer.Command.Compiler do
           aliases: unquote(aliases),
           usage: unquote(usage),
           hide: unquote(hide),
+          deprecated: unquote(deprecated),
           subcommand_required: unquote(subcommand_required),
           propagate_version: unquote(propagate_version),
           infer_subcommands: unquote(infer_subcommands),

--- a/lib/cheer/command/dsl.ex
+++ b/lib/cheer/command/dsl.ex
@@ -54,6 +54,17 @@ defmodule Cheer.Command.DSL do
   """
   defmacro hide(val \\ true), do: quote(do: @cheer_hide(unquote(val)))
 
+  @doc """
+  Mark this command as deprecated. Shows a `(deprecated)` marker in the parent's
+  help and prints a warning to stderr when the command is used. Pass a string to
+  include a reason (and a migration hint).
+
+      command "old-name" do
+        deprecated "use `new-name` instead"
+      end
+  """
+  defmacro deprecated(val \\ true), do: quote(do: @cheer_deprecated(unquote(val)))
+
   @doc "Require that a subcommand is provided (error instead of showing help)."
   defmacro subcommand_required(val), do: quote(do: @cheer_subcommand_required(unquote(val)))
 

--- a/lib/cheer/help.ex
+++ b/lib/cheer/help.ex
@@ -61,7 +61,12 @@ defmodule Cheer.Help do
         sub_meta = sub.__cheer_meta__()
         cmd_aliases = Map.get(sub_meta, :aliases, [])
         alias_str = if cmd_aliases != [], do: " (#{Enum.join(cmd_aliases, ", ")})", else: ""
-        IO.puts("  #{String.pad_trailing(sub_meta.name <> alias_str, 20)} #{sub_meta.about}")
+        dep = Enum.join(deprecated_label(Map.get(sub_meta, :deprecated)), "")
+        dep = if dep != "", do: " " <> dep, else: ""
+
+        IO.puts(
+          "  #{String.pad_trailing(sub_meta.name <> alias_str, 20)} #{sub_meta.about}#{dep}"
+        )
       end
 
       IO.puts("")
@@ -83,7 +88,12 @@ defmodule Cheer.Help do
         display_name = Keyword.get(arg_opts, :value_name, Atom.to_string(name))
         help = pick_help(arg_opts, long)
         required = if Keyword.get(arg_opts, :required, false), do: " (required)", else: ""
-        IO.puts("  #{String.pad_trailing("<#{display_name}>", 20)} #{help}#{required}")
+        deprecated = Enum.join(deprecated_label(Keyword.get(arg_opts, :deprecated)), "")
+        deprecated = if deprecated != "", do: " " <> deprecated, else: ""
+
+        IO.puts(
+          "  #{String.pad_trailing("<#{display_name}>", 20)} #{help}#{required}#{deprecated}"
+        )
       end
 
       if has_trailing do
@@ -172,6 +182,12 @@ defmodule Cheer.Help do
 
   defp maybe_append(list, nil, _fun), do: list
   defp maybe_append(list, value, fun), do: list ++ [fun.(value)]
+
+  # `:deprecated` is `true` for a bare marker or a string for a reason.
+  defp deprecated_label(nil), do: []
+  defp deprecated_label(false), do: []
+  defp deprecated_label(true), do: ["(deprecated)"]
+  defp deprecated_label(msg) when is_binary(msg), do: ["(deprecated: #{msg})"]
 
   # Render a default for the "[default: ...]" suffix. Most defaults are strings
   # or numbers; a value with no String.Chars implementation (a map) or a
@@ -284,6 +300,8 @@ defmodule Cheer.Help do
         nil -> suffixes
         spec -> suffixes ++ [num_args_label(spec)]
       end
+
+    suffixes = suffixes ++ deprecated_label(Keyword.get(opt_opts, :deprecated))
 
     suffix = if suffixes != [], do: " " <> Enum.join(suffixes, " "), else: ""
 

--- a/lib/cheer/router.ex
+++ b/lib/cheer/router.ex
@@ -131,8 +131,9 @@ defmodule Cheer.Router do
 
     case match_subcommand(meta.subcommands, argv, infer?) do
       {:ok, sub_module, rest} ->
-        sub_name = sub_module.__cheer_meta__().name
-        child_opts = Keyword.update!(opts, :prog, &"#{&1} #{sub_name}")
+        sub_meta = sub_module.__cheer_meta__()
+        warn_deprecated_command(sub_meta)
+        child_opts = Keyword.update!(opts, :prog, &"#{&1} #{sub_meta.name}")
         dispatch_with_hooks(sub_module, rest, child_opts, hooks)
 
       {:ambiguous, token, candidates} ->
@@ -318,6 +319,7 @@ defmodule Cheer.Router do
                # Include arguments so argument-level :validate and :choices run.
                :ok <- validate_params(args, all_options ++ meta.arguments, arg_names),
                :ok <- run_validators(args, Map.get(meta, :validators, [])) do
+            warn_deprecated_options(all_options, provided)
             {:ok, args}
           else
             {:error, msg} ->
@@ -397,6 +399,7 @@ defmodule Cheer.Router do
                # Include arguments so argument-level :validate and :choices run.
                :ok <- validate_params(args, all_options ++ meta.arguments, arg_names),
                :ok <- run_validators(args, Map.get(meta, :validators, [])) do
+            warn_deprecated_options(all_options, provided)
             {:ok, args}
           else
             {:error, msg} ->
@@ -1171,6 +1174,37 @@ defmodule Cheer.Router do
     |> Enum.take_while(&(&1 != "--"))
     |> Enum.any?(&(&1 in targets))
   end
+
+  # -- Deprecation warnings --
+
+  defp warn_deprecated_options(options, provided) do
+    for {name, opts} <- options, MapSet.member?(provided, name) do
+      case Keyword.get(opts, :deprecated) do
+        dep when dep not in [nil, false] ->
+          IO.puts(:stderr, deprecation_message("--#{flag_string(name)}", dep))
+
+        _ ->
+          :ok
+      end
+    end
+
+    :ok
+  end
+
+  defp warn_deprecated_command(meta) do
+    case Map.get(meta, :deprecated, false) do
+      dep when dep not in [nil, false] ->
+        IO.puts(:stderr, deprecation_message("command '#{meta.name}'", dep))
+
+      _ ->
+        :ok
+    end
+  end
+
+  defp deprecation_message(label, true), do: "warning: #{label} is deprecated"
+
+  defp deprecation_message(label, msg) when is_binary(msg),
+    do: "warning: #{label} is deprecated: #{msg}"
 
   # -- Output helpers --
 

--- a/test/cheer_test.exs
+++ b/test/cheer_test.exs
@@ -3399,4 +3399,76 @@ defmodule CheerTest do
       assert output =~ "--ids: no bad"
     end
   end
+
+  # -- Deprecation markers (#106) ----------------------------------------------
+
+  defmodule TestDeprecatedSub do
+    use Cheer.Command
+
+    command "old" do
+      about("Legacy command")
+      deprecated("use `new` instead")
+    end
+
+    @impl Cheer.Command
+    def run(_args, _raw), do: :ran
+  end
+
+  defmodule TestDeprecatedLeaf do
+    use Cheer.Command
+
+    command "dep" do
+      option(:legacy, type: :string, deprecated: true, help: "old flag")
+      option(:soon, type: :string, deprecated: "use --now", help: "phasing out")
+      option(:current, type: :string, help: "fine")
+    end
+
+    @impl Cheer.Command
+    def run(args, _raw), do: {:ok, args}
+  end
+
+  defmodule TestDeprecatedRoot do
+    use Cheer.Command
+
+    command "app" do
+      about("root")
+      subcommand(TestDeprecatedSub)
+    end
+  end
+
+  describe "deprecation markers (#106)" do
+    test "help shows a (deprecated) marker on options, with the reason if given" do
+      output = capture_io(fn -> Cheer.run(TestDeprecatedLeaf, ["--help"]) end)
+      assert output =~ "old flag (deprecated)"
+      assert output =~ "phasing out (deprecated: use --now)"
+    end
+
+    test "help shows a (deprecated) marker on a subcommand" do
+      output = capture_io(fn -> Cheer.run(TestDeprecatedRoot, ["--help"]) end)
+      assert output =~ "old"
+      assert output =~ "(deprecated: use `new` instead)"
+    end
+
+    test "using a deprecated option warns to stderr but still runs" do
+      warnings = capture_io(:stderr, fn -> Cheer.run(TestDeprecatedLeaf, ["--legacy", "x"]) end)
+      assert warnings =~ "warning: --legacy is deprecated"
+    end
+
+    test "a deprecated option with a reason includes it in the warning" do
+      warnings = capture_io(:stderr, fn -> Cheer.run(TestDeprecatedLeaf, ["--soon", "y"]) end)
+      assert warnings =~ "warning: --soon is deprecated: use --now"
+    end
+
+    test "a non-deprecated option produces no warning" do
+      warnings = capture_io(:stderr, fn -> Cheer.run(TestDeprecatedLeaf, ["--current", "z"]) end)
+      refute warnings =~ "deprecated"
+    end
+
+    test "dispatching a deprecated subcommand warns and still runs" do
+      warnings =
+        capture_io(:stderr, fn -> assert Cheer.run(TestDeprecatedRoot, ["old"]) == :ran end)
+
+      assert warnings =~ "warning: command 'old' is deprecated: use `new` instead"
+    end
+  end
 end


### PR DESCRIPTION
Closes #106.

Mark an option/argument deprecated with `:deprecated`, or a subcommand with the command-level `deprecated` setting. Pass `true` for a bare marker or a string for a reason:

```elixir
option :old_flag, type: :string, deprecated: "use --new-flag"

command "old-name" do
  deprecated "use `new-name` instead"
end
```

- **Help** shows a `(deprecated)` marker (with the reason, if given) on the option/argument/subcommand.
- **On use**, a deprecated option or a dispatched deprecated subcommand prints a warning to stderr (`warning: --old-flag is deprecated: use --new-flag`).
- Deprecated items stay fully functional.

The subcommand setting reuses the `hide` pattern (DSL macro + `:cheer_deprecated` attribute + meta). Doc + tests added; 325 tests green.