### PR TITLE
feat: positional variadic arguments (num_args on positionals)

### DIFF
--- a/lib/cheer/command/dsl.ex
+++ b/lib/cheer/command/dsl.ex
@@ -170,6 +170,10 @@ defmodule Cheer.Command.DSL do
 
     * `:type` - `:string` (default), `:integer`, `:float`, or `:boolean`
     * `:required` - `true` or `false` (default)
+    * `:num_args` - collect several positional tokens into a list: an integer for
+      an exact count or a range (`1..3`) for a variable count. Consumption is
+      greedy (up to the max), so a variadic argument should be declared last. Too
+      few values is a usage error.
     * `:help` - help text shown in `--help`
     * `:long_help` - extended help text shown by `--help` (long form)
     * `:value_name` - placeholder name in help (e.g. `"FILE"`)

--- a/lib/cheer/router.ex
+++ b/lib/cheer/router.ex
@@ -256,19 +256,10 @@ defmodule Cheer.Router do
       args = Map.merge(args, hyphen_values)
       args = apply_value_delimiters(args, all_options)
 
-      {declared_positional, rest_args} = Enum.split(positional, length(meta.arguments))
+      {positional_map, rest_args, supplied_positional} =
+        assign_positionals(meta.arguments, positional)
 
-      supplied_positional =
-        meta.arguments
-        |> Enum.zip(declared_positional)
-        |> Enum.map(fn {{name, _opts}, _value} -> name end)
-
-      args =
-        meta.arguments
-        |> Enum.zip(declared_positional)
-        |> Enum.reduce(args, fn {{name, arg_opts}, value}, acc ->
-          Map.put(acc, name, coerce_arg(value, arg_opts))
-        end)
+      args = Map.merge(args, positional_map)
 
       # Names the user actually supplied (parsed flags, num_args flags, and
       # positionals present in argv). Constraint checks key off this rather than
@@ -306,6 +297,10 @@ defmodule Cheer.Router do
       cond do
         missing != [] ->
           print_missing_args_error(command, missing, opts)
+          :handled
+
+        pos_error = positional_count_error(meta.arguments, positional_map) ->
+          IO.puts("error: #{pos_error}")
           :handled
 
         true ->
@@ -429,6 +424,58 @@ defmodule Cheer.Router do
     end)
     |> Enum.map(fn {name, _o} -> name end)
   end
+
+  # -- Positional arguments --
+
+  # Assign positional tokens to declared arguments left to right. A plain
+  # argument takes one token; an argument with `:num_args` greedily takes up to
+  # `max` tokens into a list. Returns {value_map, remaining_tokens, supplied}.
+  defp assign_positionals(arguments, positional) do
+    Enum.reduce(arguments, {%{}, positional, []}, fn {name, opts}, {acc, remaining, supplied} ->
+      case Keyword.get(opts, :num_args) do
+        nil ->
+          case remaining do
+            [value | rest] ->
+              {Map.put(acc, name, coerce_arg(value, opts)), rest, [name | supplied]}
+
+            [] ->
+              {acc, [], supplied}
+          end
+
+        spec ->
+          {_min, max} = num_args_bounds(spec)
+          {taken, rest} = Enum.split(remaining, max)
+          values = Enum.map(taken, &coerce_arg(&1, opts))
+          supplied = if taken == [], do: supplied, else: [name | supplied]
+          {Map.put(acc, name, values), rest, supplied}
+      end
+    end)
+  end
+
+  # A `:num_args` positional must receive between min and max tokens. Consumption
+  # caps at max, so only the too-few case fails here. Returns the message or nil.
+  defp positional_count_error(arguments, positional_map) do
+    Enum.find_value(arguments, fn {name, opts} ->
+      case Keyword.get(opts, :num_args) do
+        nil ->
+          nil
+
+        spec ->
+          {min, max} = num_args_bounds(spec)
+          got = length(Map.get(positional_map, name, []))
+
+          if got >= min and got <= max,
+            do: nil,
+            else: positional_num_args_error(name, min, max, got)
+      end
+    end)
+  end
+
+  defp positional_num_args_error(name, min, max, got) when min == max,
+    do: "<#{name}> expects #{min} value(s), got #{got}"
+
+  defp positional_num_args_error(name, min, max, got),
+    do: "<#{name}> expects between #{min} and #{max} values, got #{got}"
 
   # -- Conditional required (required_if / required_unless) --
 

--- a/test/cheer_test.exs
+++ b/test/cheer_test.exs
@@ -3471,4 +3471,71 @@ defmodule CheerTest do
       assert warnings =~ "warning: command 'old' is deprecated: use `new` instead"
     end
   end
+
+  # -- Positional variadic arguments (#104) ------------------------------------
+
+  defmodule TestPositionalRange do
+    use Cheer.Command
+
+    command "pr" do
+      argument(:files, type: :string, num_args: 1..3)
+    end
+
+    @impl Cheer.Command
+    def run(args, _raw), do: {:ok, args}
+  end
+
+  defmodule TestPositionalExact do
+    use Cheer.Command
+
+    command "pe" do
+      argument(:point, type: :integer, num_args: 2)
+    end
+
+    @impl Cheer.Command
+    def run(args, _raw), do: {:ok, args}
+  end
+
+  defmodule TestPositionalMixed do
+    use Cheer.Command
+
+    command "pm" do
+      argument(:cmd, type: :string, required: true)
+      argument(:extra, type: :string, num_args: 1..2)
+    end
+
+    @impl Cheer.Command
+    def run(args, _raw), do: {:ok, args}
+  end
+
+  describe "positional variadic arguments (#104)" do
+    test "a range collects a variable number of tokens into a list" do
+      assert {:ok, %{files: ["a"]}} = Cheer.run(TestPositionalRange, ["a"])
+      assert {:ok, %{files: ["a", "b", "c"]}} = Cheer.run(TestPositionalRange, ["a", "b", "c"])
+    end
+
+    test "too few tokens for a range is a usage error" do
+      output = capture_io(fn -> Cheer.run(TestPositionalRange, []) end)
+      assert output =~ "<files> expects between 1 and 3 values, got 0"
+    end
+
+    test "an exact count coerces each element" do
+      assert {:ok, %{point: [1, 2]}} = Cheer.run(TestPositionalExact, ["1", "2"])
+    end
+
+    test "an exact count with the wrong number is a usage error" do
+      output = capture_io(fn -> Cheer.run(TestPositionalExact, ["1"]) end)
+      assert output =~ "<point> expects 2 value(s), got 1"
+    end
+
+    test "a fixed argument before a variadic one consumes one token first" do
+      assert {:ok, %{cmd: "go", extra: ["x", "y"]}} =
+               Cheer.run(TestPositionalMixed, ["go", "x", "y"])
+    end
+
+    test "the variadic argument still enforces its minimum after a fixed one" do
+      output = capture_io(fn -> Cheer.run(TestPositionalMixed, ["go"]) end)
+      assert output =~ "<extra> expects between 1 and 2 values, got 0"
+    end
+  end
 end


### PR DESCRIPTION
Closes #104.

Adds `:num_args` on `argument` so a positional can collect several tokens into a list:

```elixir
argument :files, type: :string, num_args: 1..3   # mytool a b c -> files: ["a","b","c"]
argument :point, type: :integer, num_args: 2      # mytool 1 2   -> point: [1, 2]
```

Consumption is greedy up to the max, so a variadic argument should be declared last; a plain argument still takes exactly one token. Too few tokens is a usage error (`<files> expects between 1 and 3 values, got 0`).

Replaces the one-token-per-argument positional split with `assign_positionals/2` and adds `positional_count_error/2`. DSL doc + tests added. 331 tests green.

Note: `:rest` remains the reserved trailing key, so avoid naming an argument `:rest`.