### PR TITLE
feat: default_missing_value for a flag present with no value

### DIFF
--- a/docs/guides/options.md
+++ b/docs/guides/options.md
@@ -108,6 +108,22 @@ Each element is coerced to the option's `:type` and validated against
 `:multi` (each occurrence is split and the results flattened). This differs
 from `:num_args`, which reads several separate tokens after one flag.
 
+## Optional value (`:default_missing_value`)
+
+`:default_missing_value` is the value a flag takes when it is present with no
+value, distinct from `:default` (the flag absent):
+
+```elixir
+option :color, type: :string, default: "auto", default_missing_value: "always"
+# (absent)      ->  args[:color] == "auto"
+# --color       ->  args[:color] == "always"
+# --color=never ->  args[:color] == "never"
+```
+
+An explicit value must use the `--flag=value` form. `--color never` leaves
+`never` as a positional argument, so `--color` still resolves to the missing
+value.
+
 ## Custom value parsers (`:parse`)
 
 `:parse` transforms a value into a domain type (an atom, a `Date`, a struct)

--- a/lib/cheer/command/dsl.ex
+++ b/lib/cheer/command/dsl.ex
@@ -223,6 +223,9 @@ defmodule Cheer.Command.DSL do
     * `:short` - single-character alias atom (e.g. `:p` for `-p`)
     * `:required` - `true` or `false` (default)
     * `:default` - default value when not provided (`:count` defaults to `0`, `:multi` defaults to `[]`)
+    * `:default_missing_value` - value used when the flag is present with no value
+      (`--color` alone). Distinct from `:default` (flag absent). An explicit value
+      must use the `--flag=value` form; `--flag value` leaves `value` as a positional.
     * `:multi` - `true` to allow repeated flags collected into a list (e.g. `--tag a --tag b`)
     * `:num_args` - collect several values from a single flag invocation into a list:
       an integer for an exact count (`num_args: 2` accepts `--point 1 2`) or a range

--- a/lib/cheer/router.ex
+++ b/lib/cheer/router.ex
@@ -233,10 +233,12 @@ defmodule Cheer.Router do
     # (and their value tokens) out of argv up front, then parse the remainder.
     {num_args_values, argv} = extract_num_args(argv, all_options)
     {hyphen_values, argv} = extract_hyphen_values(argv, all_options)
+    {missing_values, argv} = extract_default_missing(argv, all_options)
 
     parser_options =
       Enum.reject(all_options, fn {_name, o} = opt ->
-        Keyword.has_key?(o, :num_args) or single_value_hyphen_opt?(opt)
+        Keyword.has_key?(o, :num_args) or single_value_hyphen_opt?(opt) or
+          default_missing_opt?(opt)
       end)
 
     {option_parser_opts, option_aliases} = build_option_parser_spec(parser_options)
@@ -254,6 +256,7 @@ defmodule Cheer.Router do
       args = Map.merge(args, parsed_map)
       args = Map.merge(args, num_args_values)
       args = Map.merge(args, hyphen_values)
+      args = Map.merge(args, missing_values)
       args = apply_value_delimiters(args, all_options)
 
       {positional_map, rest_args, supplied_positional} =
@@ -268,7 +271,8 @@ defmodule Cheer.Router do
       provided =
         MapSet.new(
           Map.keys(parsed_map) ++
-            Map.keys(num_args_values) ++ Map.keys(hyphen_values) ++ supplied_positional
+            Map.keys(num_args_values) ++
+            Map.keys(hyphen_values) ++ Map.keys(missing_values) ++ supplied_positional
         )
 
       args =
@@ -975,6 +979,47 @@ defmodule Cheer.Router do
     Keyword.get(o, :allow_hyphen_values, false) and
       not Keyword.has_key?(o, :num_args) and
       Keyword.get(o, :type, :string) not in [:boolean, :count]
+  end
+
+  # Options with `default_missing_value` take a value only via the `--flag=value`
+  # form; a bare `--flag` yields the missing value and never consumes a following
+  # token (which OptionParser would otherwise treat as the value). Resolve them in
+  # a pre-pass, like the num_args/hyphen extractions.
+  defp extract_default_missing(argv, options) do
+    dmv_opts = Enum.filter(options, &default_missing_opt?/1)
+
+    if dmv_opts == [] do
+      {%{}, argv}
+    else
+      do_extract_default_missing(argv, num_args_lookup(dmv_opts), %{}, [])
+    end
+  end
+
+  defp default_missing_opt?({_name, o}) do
+    Keyword.has_key?(o, :default_missing_value) and
+      not Keyword.has_key?(o, :num_args) and
+      Keyword.get(o, :type, :string) not in [:boolean, :count]
+  end
+
+  defp do_extract_default_missing([], _lookup, collected, residual),
+    do: {collected, Enum.reverse(residual)}
+
+  defp do_extract_default_missing(["--" | rest], _lookup, collected, residual),
+    do: {collected, Enum.reverse(residual) ++ ["--" | rest]}
+
+  defp do_extract_default_missing([token | rest], lookup, collected, residual) do
+    case num_args_flag(token, lookup) do
+      {{name, opts}, nil} ->
+        value = Keyword.fetch!(opts, :default_missing_value)
+        do_extract_default_missing(rest, lookup, Map.put(collected, name, value), residual)
+
+      {{name, opts}, inline} ->
+        value = coerce_arg(inline, opts)
+        do_extract_default_missing(rest, lookup, Map.put(collected, name, value), residual)
+
+      :nomatch ->
+        do_extract_default_missing(rest, lookup, collected, [token | residual])
+    end
   end
 
   defp do_extract_hyphen_values([], _lookup, collected, residual, _head?),

--- a/test/cheer_test.exs
+++ b/test/cheer_test.exs
@@ -3538,4 +3538,43 @@ defmodule CheerTest do
       assert output =~ "<extra> expects between 1 and 2 values, got 0"
     end
   end
+
+  # -- default_missing_value (#103) --------------------------------------------
+
+  defmodule TestDefaultMissing do
+    use Cheer.Command
+
+    command "dm" do
+      option(:color, type: :string, default: "auto", default_missing_value: "always")
+      option(:level, type: :integer, default: 0, default_missing_value: 3)
+      argument(:file, type: :string, required: false)
+    end
+
+    @impl Cheer.Command
+    def run(args, _raw), do: {:ok, args}
+  end
+
+  describe "default_missing_value (#103)" do
+    test "an absent flag uses :default" do
+      assert {:ok, %{color: "auto"}} = Cheer.run(TestDefaultMissing, [])
+    end
+
+    test "a bare flag uses the missing value" do
+      assert {:ok, %{color: "always"}} = Cheer.run(TestDefaultMissing, ["--color"])
+    end
+
+    test "an explicit --flag=value overrides both" do
+      assert {:ok, %{color: "never"}} = Cheer.run(TestDefaultMissing, ["--color=never"])
+    end
+
+    test "a space-separated token stays a positional, not the value" do
+      assert {:ok, %{color: "always", file: "myfile"}} =
+               Cheer.run(TestDefaultMissing, ["--color", "myfile"])
+    end
+
+    test "the missing value and an inline value are typed" do
+      assert {:ok, %{level: 3}} = Cheer.run(TestDefaultMissing, ["--level"])
+      assert {:ok, %{level: 7}} = Cheer.run(TestDefaultMissing, ["--level=7"])
+    end
+  end
 end


### PR DESCRIPTION
Closes #103.

Adds `:default_missing_value` — the value a flag takes when present with no value, distinct from `:default` (flag absent):

```elixir
option :color, type: :string, default: "auto", default_missing_value: "always"
# (absent)      -> "auto"
# --color       -> "always"
# --color=never -> "never"
```

An explicit value must use `--flag=value`; `--color never` leaves `never` as a positional (so `--color` still resolves to the missing value). This `=`-required rule is the only unambiguous option, matching clap.

Resolved in a pre-pass (`extract_default_missing`) since OptionParser can't express an optional-value flag. Scoped to the standard parse path (not `external_subcommands`, documented). DSL + guide docs and tests added; 336 tests green.