### PR TITLE
feat: wrap long help descriptions to terminal width

### DIFF
--- a/docs/guides/help_and_output.md
+++ b/docs/guides/help_and_output.md
@@ -139,6 +139,14 @@ warning: --old-flag is deprecated: use --new-flag
 warning: command 'old-name' is deprecated: use `new-name` instead
 ```
 
+## Line wrapping
+
+When help is printed to an interactive terminal, long option and argument
+descriptions wrap to the terminal width, with continuation lines hanging-indented
+under the description column. When output is not a tty (piped, redirected, or
+captured in tests), descriptions render on single lines unchanged, so scripts
+and snapshots stay stable.
+
 ## Flag naming
 
 Cheer converts atom option names to kebab-case in both the parser and help

--- a/lib/cheer/help.ex
+++ b/lib/cheer/help.ex
@@ -92,7 +92,10 @@ defmodule Cheer.Help do
         deprecated = if deprecated != "", do: " " <> deprecated, else: ""
 
         IO.puts(
-          "  #{String.pad_trailing("<#{display_name}>", 20)} #{help}#{required}#{deprecated}"
+          wrap_line(
+            "  #{String.pad_trailing("<#{display_name}>", 20)} ",
+            "#{help}#{required}#{deprecated}"
+          )
         )
       end
 
@@ -182,6 +185,52 @@ defmodule Cheer.Help do
 
   defp maybe_append(list, nil, _fun), do: list
   defp maybe_append(list, value, fun), do: list ++ [fun.(value)]
+
+  # Terminal width for wrapping, or `:no_wrap` when output is not a tty (piped,
+  # captured in tests, CI). When not a tty, help renders on single lines exactly
+  # as before, so wrapping never changes non-interactive output.
+  defp terminal_width do
+    case :io.columns() do
+      {:ok, cols} when cols > 0 -> cols
+      _ -> :no_wrap
+    end
+  end
+
+  # Place `desc` after `prefix`, wrapping to the terminal width with continuation
+  # lines hanging-indented under the description column.
+  defp wrap_line(prefix, desc) do
+    width = terminal_width()
+    indent = String.length(prefix)
+    avail = if width == :no_wrap, do: 0, else: width - indent
+
+    if width == :no_wrap or avail < 12 or String.length(prefix) + String.length(desc) <= width do
+      prefix <> desc
+    else
+      prefix <> wrap_text(desc, avail, indent)
+    end
+  end
+
+  @doc false
+  # Wrap `text` to `width` columns, joining lines with a newline + `indent`
+  # spaces. The first line carries no leading indent (it follows a prefix).
+  def wrap_text(text, width, indent) do
+    {lines, current} =
+      text
+      |> String.split(" ", trim: true)
+      |> Enum.reduce({[], ""}, fn word, {lines, current} ->
+        candidate = if current == "", do: word, else: current <> " " <> word
+
+        if String.length(candidate) > width and current != "" do
+          {[current | lines], word}
+        else
+          {lines, candidate}
+        end
+      end)
+
+    [current | lines]
+    |> Enum.reverse()
+    |> Enum.join("\n" <> String.duplicate(" ", indent))
+  end
 
   # `:deprecated` is `true` for a bare marker or a string for a reason.
   defp deprecated_label(nil), do: []
@@ -305,7 +354,10 @@ defmodule Cheer.Help do
 
     suffix = if suffixes != [], do: " " <> Enum.join(suffixes, " "), else: ""
 
-    "  #{short}--#{String.pad_trailing(flag_name <> value_suffix, 16)} #{help}#{suffix}"
+    wrap_line(
+      "  #{short}--#{String.pad_trailing(flag_name <> value_suffix, 16)} ",
+      "#{help}#{suffix}"
+    )
   end
 
   # Render an option name as the long flag the parser accepts.

--- a/test/cheer_test.exs
+++ b/test/cheer_test.exs
@@ -3577,4 +3577,28 @@ defmodule CheerTest do
       assert {:ok, %{level: 7}} = Cheer.run(TestDefaultMissing, ["--level=7"])
     end
   end
+
+  # -- Help text wrapping (#101) -----------------------------------------------
+
+  describe "Cheer.Help.wrap_text/3 (#101)" do
+    test "wraps to width with a hanging indent, first line unindented" do
+      assert Cheer.Help.wrap_text("one two three four five six", 11, 4) ==
+               "one two\n    three four\n    five six"
+    end
+
+    test "text shorter than the width is unchanged" do
+      assert Cheer.Help.wrap_text("short enough", 40, 4) == "short enough"
+    end
+
+    test "a single word longer than the width is not broken" do
+      assert Cheer.Help.wrap_text("supercalifragilistic", 8, 2) == "supercalifragilistic"
+    end
+
+    test "help renders on single lines when output is not a tty (unchanged)" do
+      # Under capture_io there is no tty, so wrapping is disabled and each option
+      # description stays on one line.
+      output = capture_io(fn -> Cheer.run(TestDefaults, ["--help"]) end)
+      refute output =~ ~r/\n\s{10,}\S/
+    end
+  end
 end


### PR DESCRIPTION
Closes #101.

Option and argument descriptions now wrap to the terminal width, with continuation lines hanging-indented under the description column.

## Safe by construction

Wrapping is gated on an interactive terminal (`:io.columns` returns a width). When output is not a tty (piped, redirected, captured in tests, CI), `:io.columns` returns an error and descriptions render on single lines **exactly as before** — so scripts, snapshots, and the existing test suite are unaffected.

The pure `wrap_text/3` is unit-tested directly (wrap-to-width, hanging indent, short-text-unchanged, long-word-not-broken). Scoped to the columned option/argument descriptions; the `about`/`long_about` paragraphs are left as authored (they may carry intentional formatting).

340 tests green.