### PR TITLE
feat: colored help and error output

### DIFF
--- a/docs/guides/help_and_output.md
+++ b/docs/guides/help_and_output.md
@@ -139,6 +139,13 @@ warning: --old-flag is deprecated: use --new-flag
 warning: command 'old-name' is deprecated: use `new-name` instead
 ```
 
+## Color
+
+When help or an error is printed to an interactive terminal, section headings are
+bold, flags are cyan, and the `error:` prefix is red. Color is disabled
+automatically when output is not a tty (piped, redirected, captured) or when the
+`NO_COLOR` environment variable is set, so scripts and snapshots stay plain.
+
 ## Line wrapping
 
 When help is printed to an interactive terminal, long option and argument

--- a/lib/cheer/ansi.ex
+++ b/lib/cheer/ansi.ex
@@ -1,0 +1,31 @@
+defmodule Cheer.Ansi do
+  @moduledoc false
+  # ANSI styling for help and error output, gated on an ANSI-capable terminal and
+  # `NO_COLOR` being unset. When output is not a tty (piped, redirected, captured
+  # in tests, CI), styling is disabled and text renders plain, so non-interactive
+  # output is byte-for-byte unchanged.
+
+  @doc "True when ANSI styling should be applied."
+  def enabled? do
+    IO.ANSI.enabled?() and System.get_env("NO_COLOR") in [nil, ""]
+  end
+
+  @doc "Wrap `text` in the given ANSI style (an atom or list of atoms) when enabled."
+  def paint(text, style) do
+    if enabled?() do
+      [style, text, :reset]
+      |> List.flatten()
+      |> IO.ANSI.format(true)
+      |> IO.iodata_to_binary()
+    else
+      text
+    end
+  end
+
+  @doc "Visible length of a string, ignoring ANSI escape sequences."
+  def visible_length(string) do
+    string
+    |> String.replace(~r/\e\[[0-9;]*m/, "")
+    |> String.length()
+  end
+end

--- a/lib/cheer/help.ex
+++ b/lib/cheer/help.ex
@@ -32,7 +32,7 @@ defmodule Cheer.Help do
     IO.puts("")
 
     if meta[:usage] do
-      IO.puts("Usage: #{meta.usage}")
+      IO.puts(Cheer.Ansi.paint("Usage:", :bright) <> " #{meta.usage}")
     else
       IO.puts(format_usage(meta, prog))
     end
@@ -55,7 +55,7 @@ defmodule Cheer.Help do
       |> sort_subcommands()
 
     if visible_subcommands != [] do
-      IO.puts("COMMANDS:")
+      IO.puts(Cheer.Ansi.paint("COMMANDS:", :bright))
 
       for sub <- visible_subcommands do
         sub_meta = sub.__cheer_meta__()
@@ -82,7 +82,7 @@ defmodule Cheer.Help do
     has_trailing = meta[:trailing_var_arg] != nil
 
     if visible_arguments != [] or has_trailing do
-      IO.puts("ARGUMENTS:")
+      IO.puts(Cheer.Ansi.paint("ARGUMENTS:", :bright))
 
       for {name, arg_opts} <- visible_arguments do
         display_name = Keyword.get(arg_opts, :value_name, Atom.to_string(name))
@@ -131,13 +131,13 @@ defmodule Cheer.Help do
       {default_section, headed_sections} = group_options_by_heading(visible_options)
 
       if default_section != [] do
-        IO.puts("OPTIONS:")
+        IO.puts(Cheer.Ansi.paint("OPTIONS:", :bright))
         for opt <- default_section, do: IO.puts(format_option(opt, long))
         IO.puts("")
       end
 
       for {heading, opts_in_heading} <- headed_sections do
-        IO.puts("#{String.upcase(heading)}:")
+        IO.puts(Cheer.Ansi.paint("#{String.upcase(heading)}:", :bright))
         for opt <- opts_in_heading, do: IO.puts(format_option(opt, long))
         IO.puts("")
       end
@@ -200,10 +200,11 @@ defmodule Cheer.Help do
   # lines hanging-indented under the description column.
   defp wrap_line(prefix, desc) do
     width = terminal_width()
-    indent = String.length(prefix)
+    # Ignore ANSI codes (e.g. a colored flag) when measuring column widths.
+    indent = Cheer.Ansi.visible_length(prefix)
     avail = if width == :no_wrap, do: 0, else: width - indent
 
-    if width == :no_wrap or avail < 12 or String.length(prefix) + String.length(desc) <= width do
+    if width == :no_wrap or avail < 12 or indent + String.length(desc) <= width do
       prefix <> desc
     else
       prefix <> wrap_text(desc, avail, indent)
@@ -293,7 +294,7 @@ defmodule Cheer.Help do
   defp format_option({name, opt_opts}, long) do
     short =
       if Keyword.has_key?(opt_opts, :short),
-        do: "-#{Keyword.get(opt_opts, :short)}, ",
+        do: Cheer.Ansi.paint("-#{Keyword.get(opt_opts, :short)}", :cyan) <> ", ",
         else: "    "
 
     help = pick_help(opt_opts, long)
@@ -354,10 +355,9 @@ defmodule Cheer.Help do
 
     suffix = if suffixes != [], do: " " <> Enum.join(suffixes, " "), else: ""
 
-    wrap_line(
-      "  #{short}--#{String.pad_trailing(flag_name <> value_suffix, 16)} ",
-      "#{help}#{suffix}"
-    )
+    flag_col = Cheer.Ansi.paint("--#{String.pad_trailing(flag_name <> value_suffix, 16)}", :cyan)
+
+    wrap_line("  #{short}#{flag_col} ", "#{help}#{suffix}")
   end
 
   # Render an option name as the long flag the parser accepts.
@@ -371,7 +371,7 @@ defmodule Cheer.Help do
   defp num_args_label(%Range{first: first, last: last}), do: "(#{first}..#{last} values)"
 
   defp format_usage(meta, prog) do
-    parts = ["Usage: #{prog}"]
+    parts = ["#{Cheer.Ansi.paint("Usage:", :bright)} #{prog}"]
 
     parts =
       if meta.subcommands != [] do

--- a/lib/cheer/router.ex
+++ b/lib/cheer/router.ex
@@ -119,7 +119,7 @@ defmodule Cheer.Router do
         {:error, :usage}
 
       _ ->
-        IO.puts("error: unknown command '#{token}'")
+        IO.puts("#{Cheer.Ansi.paint("error:", :red)} unknown command '#{token}'")
         {:error, :usage}
     end
   end
@@ -154,7 +154,7 @@ defmodule Cheer.Router do
         {:error, :usage}
 
       :none when meta.subcommands != [] and meta.subcommand_required ->
-        IO.puts("error: a subcommand is required")
+        IO.puts("#{Cheer.Ansi.paint("error:", :red)} a subcommand is required")
         IO.puts("")
         Cheer.Help.print(command, opts)
         {:error, :usage}
@@ -304,7 +304,7 @@ defmodule Cheer.Router do
           :handled
 
         pos_error = positional_count_error(meta.arguments, positional_map) ->
-          IO.puts("error: #{pos_error}")
+          IO.puts("#{Cheer.Ansi.paint("error:", :red)} #{pos_error}")
           :handled
 
         true ->
@@ -322,7 +322,7 @@ defmodule Cheer.Router do
             {:ok, args}
           else
             {:error, msg} ->
-              IO.puts("error: #{msg}")
+              IO.puts("#{Cheer.Ansi.paint("error:", :red)} #{msg}")
               :handled
           end
       end
@@ -402,7 +402,7 @@ defmodule Cheer.Router do
             {:ok, args}
           else
             {:error, msg} ->
-              IO.puts("error: #{msg}")
+              IO.puts("#{Cheer.Ansi.paint("error:", :red)} #{msg}")
               :handled
           end
       end
@@ -933,7 +933,7 @@ defmodule Cheer.Router do
   end
 
   defp print_ambiguous_subcommand(token, candidates) do
-    IO.puts("error: '#{token}' is ambiguous")
+    IO.puts("#{Cheer.Ansi.paint("error:", :red)} '#{token}' is ambiguous")
     IO.puts("candidates: #{Enum.join(candidates, ", ")}")
   end
 
@@ -1310,7 +1310,7 @@ defmodule Cheer.Router do
   end
 
   defp print_unknown_command(meta, token) do
-    IO.puts("error: unknown command '#{token}'")
+    IO.puts("#{Cheer.Ansi.paint("error:", :red)} unknown command '#{token}'")
 
     # Hidden commands stay dispatchable but are not advertised in suggestions or
     # the available-commands list.
@@ -1358,14 +1358,14 @@ defmodule Cheer.Router do
 
   defp print_missing_args_error(command, missing_names, opts) do
     labels = Enum.map_join(missing_names, ", ", &"<#{&1}>")
-    IO.puts("error: missing required argument(s): #{labels}")
+    IO.puts("#{Cheer.Ansi.paint("error:", :red)} missing required argument(s): #{labels}")
     IO.puts("")
     Cheer.Help.print(command, opts)
   end
 
   defp print_invalid_options_error(command, invalid, opts, all_options) do
     flags = Enum.map_join(invalid, ", ", fn {flag, _} -> flag end)
-    IO.puts("error: unknown option(s): #{flags}")
+    IO.puts("#{Cheer.Ansi.paint("error:", :red)} unknown option(s): #{flags}")
 
     candidates = option_name_candidates(all_options)
 

--- a/test/cheer_test.exs
+++ b/test/cheer_test.exs
@@ -3601,4 +3601,25 @@ defmodule CheerTest do
       refute output =~ ~r/\n\s{10,}\S/
     end
   end
+
+  # -- Colored output (#102) ---------------------------------------------------
+
+  describe "Cheer.Ansi (#102)" do
+    test "paint returns plain text when styling is disabled (non-tty)" do
+      assert Cheer.Ansi.paint("hello", :red) == "hello"
+    end
+
+    test "visible_length ignores ANSI escape sequences" do
+      assert Cheer.Ansi.visible_length("\e[31mred\e[0m") == 3
+      assert Cheer.Ansi.visible_length("plain") == 5
+    end
+
+    test "help and error output contain no ANSI codes when not a tty" do
+      help = capture_io(fn -> Cheer.run(TestDefaults, ["--help"]) end)
+      refute help =~ "\e["
+
+      err = capture_io(fn -> Cheer.run(TestDefaults, ["--nope", "x"]) end)
+      refute err =~ "\e["
+    end
+  end
 end


### PR DESCRIPTION
Closes #102.

Adds ANSI styling via a small `Cheer.Ansi` module:
- **bold** section headings (`USAGE:`/`OPTIONS:`/`COMMANDS:`/`ARGUMENTS:` + custom headings)
- **cyan** flags
- **red** `error:` prefix

## Safe and standard

Gated on `IO.ANSI.enabled?()` (an ANSI-capable tty) **and** `NO_COLOR` being unset. When output is not a tty (piped, redirected, captured in tests, CI) or `NO_COLOR` is set, text renders plain and non-interactive output is byte-for-byte unchanged — so the existing suite and any snapshots are unaffected. No `--color` flag (auto only, as discussed).

The help wrapper (#101) measures column widths with `Cheer.Ansi.visible_length/1` (strips ANSI), so a colored flag doesn't throw off alignment or the wrap indent. Verified force-on (codes present), off (plain), and `NO_COLOR` gating. 343 tests green.