### PR TITLE
feat: markdown reference generation (Cheer.Reference)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ Cheer.run(MyApp.CLI.Greet, ["world", "--loud"], prog: "greet")
 - Shell completion for bash, zsh, fish, and PowerShell
 - REPL mode driven by the same command tree
 - In-process test runner with output capture
-- Command tree introspection (`Cheer.tree/1`) for docs and scripts
+- Command tree introspection (`Cheer.tree/1`) and markdown reference generation
+  (`Cheer.Reference`)
 - Zero runtime dependencies
 
 ## Install

--- a/lib/cheer/reference.ex
+++ b/lib/cheer/reference.ex
@@ -1,0 +1,163 @@
+defmodule Cheer.Reference do
+  @moduledoc """
+  Generate a reference document for a command tree, suitable for a docs site or a
+  repository reference page. Derives everything from `Cheer.tree/1`, so hidden
+  options, arguments, and subcommands are omitted.
+
+  ## Usage
+
+      iex> Cheer.Reference.generate(MyApp.CLI, :markdown, prog: "myapp")
+
+  Currently supports the `:markdown` format.
+  """
+
+  @doc """
+  Render a reference document for the command tree rooted at `root`.
+
+  Options:
+    * `:prog` - program name for the top-level heading (default: root command name)
+  """
+  @spec generate(module(), :markdown, keyword()) :: String.t()
+  def generate(root, format \\ :markdown, opts \\ [])
+
+  def generate(root, :markdown, opts) do
+    tree = Cheer.tree(root)
+    prog = Keyword.get(opts, :prog, tree.name)
+
+    tree
+    |> render_command(prog, 1)
+    |> String.trim_trailing()
+    |> Kernel.<>("\n")
+  end
+
+  # -- Command --
+
+  defp render_command(tree, path, level) do
+    [
+      "#{String.duplicate("#", level)} #{path}",
+      paragraph(tree.about),
+      usage_section(tree, path),
+      arguments_section(tree),
+      options_section(tree),
+      subcommands_section(tree, path, level)
+    ]
+    |> Enum.reject(&(&1 == ""))
+    |> Enum.join("\n\n")
+  end
+
+  defp usage_section(tree, path) do
+    opts = if tree.options == [], do: "", else: " [OPTIONS]"
+
+    args =
+      tree.arguments
+      |> Enum.map(fn {name, o} ->
+        label = "<#{value_name(name, o)}>"
+        if Keyword.get(o, :required, false), do: " #{label}", else: " [#{label}]"
+      end)
+      |> Enum.join()
+
+    trailing =
+      case tree.trailing_var_arg do
+        {name, _} -> " [<#{name}>...]"
+        _ -> ""
+      end
+
+    "```\n#{path}#{opts}#{args}#{trailing}\n```"
+  end
+
+  defp arguments_section(%{arguments: [], trailing_var_arg: nil}), do: ""
+
+  defp arguments_section(tree) do
+    bullets =
+      Enum.map(tree.arguments, fn {name, o} ->
+        "- `<#{value_name(name, o)}>`" <> help_and_meta(o, argument_meta(o))
+      end)
+
+    trailing =
+      case tree.trailing_var_arg do
+        {name, o} -> ["- `<#{name}>...`" <> help_and_meta(o, [])]
+        _ -> []
+      end
+
+    "**Arguments**\n\n" <> Enum.join(bullets ++ trailing, "\n")
+  end
+
+  defp options_section(%{options: []}), do: ""
+
+  defp options_section(tree) do
+    bullets = Enum.map(tree.options, fn opt -> "- " <> option_flags(opt) <> option_tail(opt) end)
+    "**Options**\n\n" <> Enum.join(bullets, "\n")
+  end
+
+  defp subcommands_section(%{subcommands: []}, _path, _level), do: ""
+
+  defp subcommands_section(tree, path, level) do
+    tree.subcommands
+    |> Enum.map(fn sub -> render_command(sub, "#{path} #{sub.name}", level + 1) end)
+    |> Enum.join("\n\n")
+  end
+
+  # -- Options / arguments --
+
+  defp option_flags({name, o}) do
+    flags =
+      ["`--#{kebab(name)}`"] ++
+        short(o) ++
+        Enum.map(Keyword.get(o, :aliases, []), &"`--#{kebab(&1)}`")
+
+    value = if takes_value?(o), do: " `<#{value_name(name, o)}>`", else: ""
+    Enum.join(flags, ", ") <> value
+  end
+
+  defp option_tail({_name, o}), do: help_and_meta(o, option_meta(o))
+
+  defp short(o) do
+    case Keyword.get(o, :short) do
+      nil -> []
+      s -> ["`-#{s}`"]
+    end
+  end
+
+  defp takes_value?(o) do
+    Keyword.get(o, :type, :string) not in [:boolean, :count]
+  end
+
+  defp option_meta(o) do
+    []
+    |> put(Keyword.get(o, :default), fn d -> "default: #{inspect_value(d)}" end)
+    |> put(Keyword.get(o, :choices), fn c -> "choices: #{Enum.join(c, ", ")}" end)
+    |> put(Keyword.get(o, :env), fn e -> "env: #{e}" end)
+    |> flag(Keyword.get(o, :required, false), "required")
+    |> flag(deprecated?(o), "deprecated")
+  end
+
+  defp argument_meta(o) do
+    []
+    |> flag(Keyword.get(o, :required, false), "required")
+    |> flag(deprecated?(o), "deprecated")
+  end
+
+  defp help_and_meta(o, meta) do
+    help = Keyword.get(o, :help, "")
+    help_str = if help != "", do: " -- #{help}", else: ""
+    meta_str = if meta == [], do: "", else: " (" <> Enum.join(meta, ", ") <> ")"
+    help_str <> meta_str
+  end
+
+  defp paragraph(""), do: ""
+  defp paragraph(nil), do: ""
+  defp paragraph(text), do: text
+
+  defp value_name(name, o), do: Keyword.get(o, :value_name, kebab(name))
+  defp kebab(name), do: name |> Atom.to_string() |> String.replace("_", "-")
+  defp deprecated?(o), do: Keyword.get(o, :deprecated, false) not in [nil, false]
+
+  defp put(list, nil, _fun), do: list
+  defp put(list, value, fun), do: list ++ [fun.(value)]
+  defp flag(list, false, _label), do: list
+  defp flag(list, nil, _label), do: list
+  defp flag(list, _truthy, label), do: list ++ [label]
+
+  defp inspect_value(v) when is_binary(v), do: v
+  defp inspect_value(v), do: inspect(v)
+end

--- a/lib/cheer/reference.ex
+++ b/lib/cheer/reference.ex
@@ -49,12 +49,10 @@ defmodule Cheer.Reference do
     opts = if tree.options == [], do: "", else: " [OPTIONS]"
 
     args =
-      tree.arguments
-      |> Enum.map(fn {name, o} ->
+      Enum.map_join(tree.arguments, fn {name, o} ->
         label = "<#{value_name(name, o)}>"
         if Keyword.get(o, :required, false), do: " #{label}", else: " [#{label}]"
       end)
-      |> Enum.join()
 
     trailing =
       case tree.trailing_var_arg do
@@ -92,9 +90,9 @@ defmodule Cheer.Reference do
   defp subcommands_section(%{subcommands: []}, _path, _level), do: ""
 
   defp subcommands_section(tree, path, level) do
-    tree.subcommands
-    |> Enum.map(fn sub -> render_command(sub, "#{path} #{sub.name}", level + 1) end)
-    |> Enum.join("\n\n")
+    Enum.map_join(tree.subcommands, "\n\n", fn sub ->
+      render_command(sub, "#{path} #{sub.name}", level + 1)
+    end)
   end
 
   # -- Options / arguments --

--- a/test/cheer_test.exs
+++ b/test/cheer_test.exs
@@ -3622,4 +3622,78 @@ defmodule CheerTest do
       refute err =~ "\e["
     end
   end
+
+  # -- Markdown reference generation (#105) ------------------------------------
+
+  defmodule TestRefSub do
+    use Cheer.Command
+
+    command "deploy" do
+      about("Deploy the app")
+      argument(:env, type: :string, required: true, help: "Environment")
+      option(:force, type: :boolean, short: :f, help: "Skip confirmation")
+    end
+
+    @impl Cheer.Command
+    def run(_args, _raw), do: :ok
+  end
+
+  defmodule TestRefHidden do
+    use Cheer.Command
+
+    command "secret" do
+      hide(true)
+    end
+
+    @impl Cheer.Command
+    def run(_args, _raw), do: :ok
+  end
+
+  defmodule TestRefRoot do
+    use Cheer.Command
+
+    command "myapp" do
+      about("A demo CLI")
+
+      option(:level,
+        type: :integer,
+        default: 1,
+        choices: [1, 2, 3],
+        env: "LVL",
+        help: "Log level"
+      )
+
+      option(:internal, type: :boolean, hide: true)
+      subcommand(TestRefSub)
+      subcommand(TestRefHidden)
+    end
+  end
+
+  describe "Cheer.Reference markdown (#105)" do
+    setup do
+      %{md: Cheer.Reference.generate(TestRefRoot, :markdown, prog: "myapp")}
+    end
+
+    test "renders the root heading, about, and usage", %{md: md} do
+      assert md =~ "# myapp"
+      assert md =~ "A demo CLI"
+      assert md =~ "```\nmyapp [OPTIONS]\n```"
+    end
+
+    test "renders options with metadata", %{md: md} do
+      assert md =~ "- `--level` `<level>` -- Log level (default: 1, choices: 1, 2, 3, env: LVL)"
+    end
+
+    test "renders subcommands as nested sections with the full path", %{md: md} do
+      assert md =~ "## myapp deploy"
+      assert md =~ "myapp deploy [OPTIONS] <env>"
+      assert md =~ "- `<env>` -- Environment (required)"
+      assert md =~ "- `--force`, `-f` -- Skip confirmation"
+    end
+
+    test "omits hidden options and subcommands", %{md: md} do
+      refute md =~ "internal"
+      refute md =~ "secret"
+    end
+  end
 end


### PR DESCRIPTION
Closes #105.

Adds `Cheer.Reference.generate(root, :markdown, opts)` to render a reference document for a command tree, for a docs site or a repo reference page:

```elixir
Cheer.Reference.generate(MyApp.CLI, :markdown, prog: "myapp")
```

- Derives everything from `Cheer.tree/1`, so hidden options/arguments/subcommands are omitted.
- Renders the root command and each subcommand as nested sections (heading = full command path), each with a usage block, arguments, and options.
- Option metadata: `default`, `choices`, `env`, `required`, `deprecated`.

Markdown is the first format (as discussed); the `generate/3` signature leaves room for others (e.g. roff/man) later. New isolated module, doesn't touch existing code. Tests + module docs added; 347 tests green.