### PR TITLE
docs: complete the reference for all shipped options and features

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,11 @@ Cheer.run(MyApp.CLI.Greet, ["world", "--loud"], prog: "greet")
 - Custom value parsers (`:parse`) that transform input into domain types
 - Per-param and cross-param validation, choices, conditional-required
 - Per-option relations (`:conflicts_with`, `:requires`) and param groups
-- Env var fallback, defaults, boolean negation (`--no-*`)
-- Auto-generated help with headings, display order, before/after text, and
-  hidden options, arguments, and subcommands (`hide`)
+- Env var fallback, defaults (including `:default_missing_value`), boolean
+  negation (`--no-*`)
+- Deprecation markers (`deprecated`) for options, arguments, and subcommands
+- Auto-generated help with headings, display order, before/after text, hidden
+  items (`hide`), terminal-width wrapping, and color (respecting `NO_COLOR`)
 - Prefix inference and `"Did you mean?"` suggestions for mistyped commands and
   flags
 - Optional subcommands (`:args_conflicts_with_subcommands`) and external

--- a/docs/cookbook/greeter.md
+++ b/docs/cookbook/greeter.md
@@ -63,7 +63,7 @@ GREETER_GREETING=Hey mix run -e 'Greeter.CLI.main(["Ada"])'
 # Hey, Ada!
 
 mix run -e 'Greeter.CLI.main(["world", "--times", "42"])'
-# error: --times must be one of: ... (validator failure)
+# error: times must be 1-10 (validator failure)
 
 mix run -e 'Greeter.CLI.main(["--help"])'
 # Usage: greeter <name> [OPTIONS]

--- a/docs/guides/arguments.md
+++ b/docs/guides/arguments.md
@@ -43,6 +43,24 @@ argument :input, type: :string, value_name: "FILE"
 # Usage: convert <FILE>
 ```
 
+## Variadic arguments (`:num_args`)
+
+An argument can collect several positional tokens into a list with `:num_args`,
+an exact integer or a range:
+
+```elixir
+argument :files, type: :string, num_args: 1..3, help: "One to three files"
+# a b c  ->  args[:files] == ["a", "b", "c"]
+
+argument :point, type: :integer, num_args: 2
+# 1 2    ->  args[:point] == [1, 2]
+```
+
+Consumption is greedy up to the max, so a variadic argument should be declared
+last; a plain argument still takes exactly one token. Too few tokens is a usage
+error (`<files> expects between 1 and 3 values, got 0`). This is a bounded
+alternative to `trailing_var_arg`, which collects an unbounded rest.
+
 ## Trailing variadic args
 
 Collect an arbitrary number of trailing tokens under a named key:
@@ -93,6 +111,15 @@ argument :internal, type: :string, hide: true
 ```
 
 Accepted by the parser; omitted from help output.
+
+## Deprecated arguments
+
+Mark an argument deprecated with `true` (a bare marker) or a string reason. The
+marker shows in help:
+
+```elixir
+argument :path, type: :string, deprecated: "use --file instead"
+```
 
 ## See also
 

--- a/lib/cheer/command/dsl.ex
+++ b/lib/cheer/command/dsl.ex
@@ -174,10 +174,12 @@ defmodule Cheer.Command.DSL do
       an exact count or a range (`1..3`) for a variable count. Consumption is
       greedy (up to the max), so a variadic argument should be declared last. Too
       few values is a usage error.
+    * `:choices` - list of allowed values
     * `:help` - help text shown in `--help`
     * `:long_help` - extended help text shown by `--help` (long form)
     * `:value_name` - placeholder name in help (e.g. `"FILE"`)
     * `:hide` - `true` to hide from help output
+    * `:deprecated` - `true` for a bare marker, or a string reason; shown in help
     * `:display_order` - integer controlling position in help (lower first)
     * `:validate` - `fn value -> :ok | {:error, msg} end`
     * `:parse` - `fn value -> {:ok, parsed} | {:error, msg} end` to transform the
@@ -250,6 +252,8 @@ defmodule Cheer.Command.DSL do
     * `:long_help` - extended help text shown by `--help` (long form)
     * `:value_name` - placeholder name in help (e.g. `"FILE"`)
     * `:hide` - `true` to hide from help output
+    * `:deprecated` - `true` for a bare marker, or a string reason; shown in help
+      and warned to stderr when the option is used
     * `:global` - `true` to propagate to all subcommands
     * `:aliases` - list of alternative long names (e.g. `[:colour]` for `:color`)
     * `:display_order` - integer controlling position within its help section (lower first)


### PR DESCRIPTION
Pre-release documentation-completeness pass (from the docs/examples audit). No code behavior changes.

- **DSL `@doc`**: add `:deprecated` to the option key list, and `:choices` + `:deprecated` to the argument key list. All three are shipped but were missing from the API reference.
- **arguments.md**: add a variadic `:num_args` section (#104) and a deprecated-arguments note.
- **README Features**: surface `:default_missing_value`, deprecation markers, and terminal-width wrapping + color.
- **greeter cookbook**: fix a stale output annotation (the custom `:times` validator prints `times must be 1-10`, not a `choices`-style message).
- **CLAUDE.md**: drop the stale "70 tests" count.

`mix docs` and `mix compile` clean.