### PR TITLE
feat: warn on deprecated argument use; close audit test-coverage gaps

### DIFF
--- a/lib/cheer/ansi.ex
+++ b/lib/cheer/ansi.ex
@@ -13,7 +13,8 @@ defmodule Cheer.Ansi do
   @doc "Wrap `text` in the given ANSI style (an atom or list of atoms) when enabled."
   def paint(text, style) do
     if enabled?() do
-      [style, text, :reset]
+      # IO.ANSI.format/2 appends the reset itself when emit? is true.
+      [style, text]
       |> List.flatten()
       |> IO.ANSI.format(true)
       |> IO.iodata_to_binary()

--- a/lib/cheer/router.ex
+++ b/lib/cheer/router.ex
@@ -319,6 +319,7 @@ defmodule Cheer.Router do
                :ok <- validate_params(args, all_options ++ meta.arguments, arg_names),
                :ok <- run_validators(args, Map.get(meta, :validators, [])) do
             warn_deprecated_options(all_options, provided)
+            warn_deprecated_arguments(meta.arguments, provided)
             {:ok, args}
           else
             {:error, msg} ->
@@ -399,6 +400,7 @@ defmodule Cheer.Router do
                :ok <- validate_params(args, all_options ++ meta.arguments, arg_names),
                :ok <- run_validators(args, Map.get(meta, :validators, [])) do
             warn_deprecated_options(all_options, provided)
+            warn_deprecated_arguments(meta.arguments, provided)
             {:ok, args}
           else
             {:error, msg} ->
@@ -1274,6 +1276,20 @@ defmodule Cheer.Router do
       case Keyword.get(opts, :deprecated) do
         dep when dep not in [nil, false] ->
           IO.puts(:stderr, deprecation_message("--#{flag_string(name)}", dep))
+
+        _ ->
+          :ok
+      end
+    end
+
+    :ok
+  end
+
+  defp warn_deprecated_arguments(arguments, provided) do
+    for {name, opts} <- arguments, MapSet.member?(provided, name) do
+      case Keyword.get(opts, :deprecated) do
+        dep when dep not in [nil, false] ->
+          IO.puts(:stderr, deprecation_message("<#{name}>", dep))
 
         _ ->
           :ok

--- a/test/ansi_test.exs
+++ b/test/ansi_test.exs
@@ -1,0 +1,53 @@
+defmodule Cheer.AnsiTest do
+  # async: false because these tests toggle the global :elixir :ansi_enabled flag.
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureIO
+
+  defmodule ColorCmd do
+    use Cheer.Command
+
+    command "c" do
+      about("demo")
+      option(:port, type: :integer, short: :p, help: "Port")
+    end
+
+    @impl Cheer.Command
+    def run(_args, _raw), do: :ok
+  end
+
+  setup do
+    prev = Application.get_env(:elixir, :ansi_enabled)
+    Application.put_env(:elixir, :ansi_enabled, true)
+    System.delete_env("NO_COLOR")
+    on_exit(fn -> Application.put_env(:elixir, :ansi_enabled, prev) end)
+    :ok
+  end
+
+  test "paint emits ANSI codes when enabled" do
+    assert Cheer.Ansi.paint("x", :red) == "\e[31mx\e[0m"
+  end
+
+  test "visible_length ignores the ANSI codes it adds" do
+    assert Cheer.Ansi.visible_length(Cheer.Ansi.paint("hello", :cyan)) == 5
+  end
+
+  test "NO_COLOR disables styling even when a tty is available" do
+    System.put_env("NO_COLOR", "1")
+    on_exit(fn -> System.delete_env("NO_COLOR") end)
+
+    refute Cheer.Ansi.enabled?()
+    assert Cheer.Ansi.paint("x", :red) == "x"
+  end
+
+  test "help output is colorized: bold heading and cyan flag" do
+    out = capture_io(fn -> Cheer.run(ColorCmd, ["--help"]) end)
+    assert out =~ "\e[1mOPTIONS:"
+    assert out =~ "\e[36m"
+  end
+
+  test "error output has a red error prefix" do
+    err = capture_io(fn -> Cheer.run(ColorCmd, ["--nope", "x"]) end)
+    assert err =~ "\e[31merror:"
+  end
+end

--- a/test/cheer_test.exs
+++ b/test/cheer_test.exs
@@ -3421,6 +3421,13 @@ defmodule CheerTest do
       option(:legacy, type: :string, deprecated: true, help: "old flag")
       option(:soon, type: :string, deprecated: "use --now", help: "phasing out")
       option(:current, type: :string, help: "fine")
+
+      argument(:oldpath,
+        type: :string,
+        required: false,
+        deprecated: "use --file",
+        help: "old arg"
+      )
     end
 
     @impl Cheer.Command
@@ -3469,6 +3476,16 @@ defmodule CheerTest do
         capture_io(:stderr, fn -> assert Cheer.run(TestDeprecatedRoot, ["old"]) == :ran end)
 
       assert warnings =~ "warning: command 'old' is deprecated: use `new` instead"
+    end
+
+    test "help shows a (deprecated) marker on an argument" do
+      output = capture_io(fn -> Cheer.run(TestDeprecatedLeaf, ["--help"]) end)
+      assert output =~ "old arg (deprecated: use --file)"
+    end
+
+    test "using a deprecated argument warns to stderr but still runs" do
+      warnings = capture_io(:stderr, fn -> Cheer.run(TestDeprecatedLeaf, ["somepath"]) end)
+      assert warnings =~ "warning: <oldpath> is deprecated: use --file"
     end
   end
 
@@ -3632,6 +3649,7 @@ defmodule CheerTest do
       about("Deploy the app")
       argument(:env, type: :string, required: true, help: "Environment")
       option(:force, type: :boolean, short: :f, help: "Skip confirmation")
+      option(:legacy, type: :string, deprecated: true, help: "old flag")
     end
 
     @impl Cheer.Command
@@ -3694,6 +3712,10 @@ defmodule CheerTest do
     test "omits hidden options and subcommands", %{md: md} do
       refute md =~ "internal"
       refute md =~ "secret"
+    end
+
+    test "marks deprecated options", %{md: md} do
+      assert md =~ "- `--legacy` `<legacy>` -- old flag (deprecated)"
     end
   end
 end


### PR DESCRIPTION
From the pre-release test-completeness audit.

## Behavior fix

Deprecated **arguments** now emit a stderr use-warning (`warning: <name> is deprecated[: reason]`), matching options and subcommands. Previously a deprecated argument rendered the help marker but never warned on use — an inconsistency the audit found.

## Bug fix

`Cheer.Ansi.paint/2` emitted a double reset (`\e[0m\e[0m`) because `IO.ANSI.format/2` already appends the reset when `emit?` is true. Surfaced by the new colored-output positive-path test.

## Coverage added

- **Colored output positive path** (the audit's top gap: `Cheer.Ansi` was only verified in the disabled direction). New `test/ansi_test.exs` (`async: false`, toggles the global ANSI flag with restore) asserts `paint` emits codes, help renders bold headings + cyan flags, errors get a red prefix, `visible_length` is correct on painted text, and `NO_COLOR` disables styling.
- **Deprecated argument**: help marker + the new use-warning.
- **`Cheer.Reference`**: deprecated-option marker.

355 tests green.