### PR TITLE
docs: link clap to its crates.io page

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Hex Docs](https://img.shields.io/badge/hex-docs-blue.svg)](https://hexdocs.pm/cheer)
 [![License](https://img.shields.io/hexpm/l/cheer.svg)](LICENSE)
 
-A clap-inspired CLI framework for Elixir. Define your command tree once and
+A [clap](https://crates.io/crates/clap)-inspired CLI framework for Elixir. Define your command tree once and
 get parsing, validation, help, shell completion, a REPL, and in-process
 testing for free.
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-Cheer is a clap-inspired CLI framework for Elixir. Define your command tree
+Cheer is a [clap](https://crates.io/crates/clap)-inspired CLI framework for Elixir. Define your command tree
 once, get parsing, validation, help, shell completion, a REPL, and in-process
 testing for free.
 

--- a/lib/cheer.ex
+++ b/lib/cheer.ex
@@ -1,6 +1,6 @@
 defmodule Cheer do
   @moduledoc """
-  A clap-inspired CLI argument parsing framework for Elixir.
+  A [clap](https://crates.io/crates/clap)-inspired CLI argument parsing framework for Elixir.
 
   Provides declarative command definitions with arbitrarily nested subcommands,
   typed options, automatic help generation, and shell completion.


### PR DESCRIPTION
Links the word `clap` in the "clap-inspired" tagline to https://crates.io/crates/clap in the README, the getting-started guide, and the `Cheer` moduledoc.

The `mix.exs` hex package description is left as plain text (hex.pm renders the description without markdown, so a link would show as literal syntax).